### PR TITLE
Parallelized Parallel Tempering

### DIFF
--- a/build/geom_defines.txt.example
+++ b/build/geom_defines.txt.example
@@ -1,3 +1,5 @@
+NREPLICAS 1
+
 LOC_N0 4 
 LOC_N1 4 
 LOC_N2 4 

--- a/build/script_compile_Open_StaPLE.sh
+++ b/build/script_compile_Open_StaPLE.sh
@@ -2,7 +2,6 @@
 
 # SIMULATION PARAMETERS
 ACTION_TYPE='TLSM'         # must be either 'WILSON' or 'TLSM'
-DO_PARALLEL_TEMPERING=1    # must be either 1==YES or 0==NO
 
 # LOCAL LIB PATH
 my_lib_path=$( echo "${LIBRARY_PATH}" | cut -d ':' -f 1 ) 
@@ -26,10 +25,6 @@ if [ "${ACTION_TYPE}" != 'TLSM' ] && [ "${ACTION_TYPE}" != 'WILSON' ]; then
 	exit 1
 fi
 
-# if [ "${DO_PARALLEL_TEMPERING}" -ne 0 ] && [ "${DO_PARALLEL_TEMPERING}" -ne 1 ]; then
-# 	echo "ERROR! PAR_TEMP set to ${PAR_TEMP} but must be either 1==YES or 0==NO"
-# 	exit 1
-# fi
 
 # COMMENT/UNCOMMENT DESIRED SIMULATION PARAMS
 commented=$( grep "#define GAUGE_ACT_${ACTION_TYPE}" ../src/Include/common_defines.h | cut -d '#' -f 1 )
@@ -41,23 +36,6 @@ else # desired action is uncommented
 	sed -i "s://#define GAUGE_ACT_${ACTION_TYPE}:#define GAUGE_ACT_${ACTION_TYPE}:g" ../src/Include/common_defines.h
 	sed -i "s:#define GAUGE_ACT_${OTHER_ACTION}://#define GAUGE_ACT_${OTHER_ACTION}:g" ../src/Include/common_defines.h
 fi
-
-# commented=$( grep "#define PAR_TEMP" ../src/Include/common_defines.h | cut -d '#' -f 1 )
-# if test -z "${commented}"; then # PAR_TEMP is uncommented
-# 	if [ "${DO_PARALLEL_TEMPERING}" -eq 1 ]; then
-# 		echo "PAR_TEMP already uncommented"
-# 	else
-# 		echo "PAR_TEMP will be commented"
-# 		sed -i "s:#define PAR_TEMP://#define PAR_TEMP:g" ../src/Include/common_defines.h
-# 	fi
-# else # PAR_TEMP is commented
-# 	if [ "${DO_PARALLEL_TEMPERING}" -eq 0 ]; then
-# 		echo "PAR_TEMP already commented"
-# 	else
-# 		echo "PAR_TEMP will be uncommented"
-# 		sed -i "s://#define PAR_TEMP:#define PAR_TEMP:g" ../src/Include/common_defines.h
-# 	fi
-# fi
 
 # CONFIGURE + COMPILE
 # if autotools are not built, build them

--- a/build/script_compile_Open_StaPLE.sh
+++ b/build/script_compile_Open_StaPLE.sh
@@ -2,7 +2,7 @@
 
 # SIMULATION PARAMETERS
 ACTION_TYPE='TLSM'         # must be either 'WILSON' or 'TLSM'
-DO_PARALLEL_TEMPERING=0    # must be either 1==YES or 0==NO
+DO_PARALLEL_TEMPERING=1    # must be either 1==YES or 0==NO
 
 # LOCAL LIB PATH
 my_lib_path=$( echo "${LIBRARY_PATH}" | cut -d ':' -f 1 ) 
@@ -17,6 +17,8 @@ cur_dir="--prefix=${PWD}"
 
 # LOAD PYTHON2.6
 module unload python
+module load profile/global
+module load pgi
 
 # CHECKS
 if [ "${ACTION_TYPE}" != 'TLSM' ] && [ "${ACTION_TYPE}" != 'WILSON' ]; then
@@ -24,10 +26,10 @@ if [ "${ACTION_TYPE}" != 'TLSM' ] && [ "${ACTION_TYPE}" != 'WILSON' ]; then
 	exit 1
 fi
 
-if [ "${DO_PARALLEL_TEMPERING}" -ne 0 ] && [ "${DO_PARALLEL_TEMPERING}" -ne 1 ]; then
-	echo "ERROR! PAR_TEMP set to ${PAR_TEMP} but must be either 1==YES or 0==NO"
-	exit 1
-fi
+# if [ "${DO_PARALLEL_TEMPERING}" -ne 0 ] && [ "${DO_PARALLEL_TEMPERING}" -ne 1 ]; then
+# 	echo "ERROR! PAR_TEMP set to ${PAR_TEMP} but must be either 1==YES or 0==NO"
+# 	exit 1
+# fi
 
 # COMMENT/UNCOMMENT DESIRED SIMULATION PARAMS
 commented=$( grep "#define GAUGE_ACT_${ACTION_TYPE}" ../src/Include/common_defines.h | cut -d '#' -f 1 )
@@ -40,28 +42,28 @@ else # desired action is uncommented
 	sed -i "s:#define GAUGE_ACT_${OTHER_ACTION}://#define GAUGE_ACT_${OTHER_ACTION}:g" ../src/Include/common_defines.h
 fi
 
-commented=$( grep "#define PAR_TEMP" ../src/Include/common_defines.h | cut -d '#' -f 1 )
-if test -z "${commented}"; then # PAR_TEMP is uncommented
-	if [ "${DO_PARALLEL_TEMPERING}" -eq 1 ]; then
-		echo "PAR_TEMP already uncommented"
-	else
-		echo "PAR_TEMP will be commented"
-		sed -i "s:#define PAR_TEMP://#define PAR_TEMP:g" ../src/Include/common_defines.h
-	fi
-else # PAR_TEMP is commented
-	if [ "${DO_PARALLEL_TEMPERING}" -eq 0 ]; then
-		echo "PAR_TEMP already commented"
-	else
-		echo "PAR_TEMP will be uncommented"
-		sed -i "s://#define PAR_TEMP:#define PAR_TEMP:g" ../src/Include/common_defines.h
-	fi
-fi
+# commented=$( grep "#define PAR_TEMP" ../src/Include/common_defines.h | cut -d '#' -f 1 )
+# if test -z "${commented}"; then # PAR_TEMP is uncommented
+# 	if [ "${DO_PARALLEL_TEMPERING}" -eq 1 ]; then
+# 		echo "PAR_TEMP already uncommented"
+# 	else
+# 		echo "PAR_TEMP will be commented"
+# 		sed -i "s:#define PAR_TEMP://#define PAR_TEMP:g" ../src/Include/common_defines.h
+# 	fi
+# else # PAR_TEMP is commented
+# 	if [ "${DO_PARALLEL_TEMPERING}" -eq 0 ]; then
+# 		echo "PAR_TEMP already commented"
+# 	else
+# 		echo "PAR_TEMP will be uncommented"
+# 		sed -i "s://#define PAR_TEMP:#define PAR_TEMP:g" ../src/Include/common_defines.h
+# 	fi
+# fi
 
 # CONFIGURE + COMPILE
 # if autotools are not built, build them
 if [ ! -f ../configure ]; then cd ../; autoreconf -f -i; cd -; fi
 # clean everything, configure, then make
-make clean
+if [ -f Makefile ];then make clean;fi
 ../configure CC="${C_comp}" CFLAGS="${C_comp_flags}" LDFLAGS="${linker_flags}" CXX="${CXX_comp}" CXXFLAGS="${CXX_comp_flags}" ${cur_dir}
 make -j 32
 

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,7 @@ fi
 
 
 
+NREPLICAS=$( grep -E "^\s*NREPLICAS\s+" $COMPILE_INFO_FILENAME | awk '{print $2}')
 LOC_N0=$( grep -E "^\s*LOC_N0\s+" $COMPILE_INFO_FILENAME | awk '{print $2}')
 LOC_N1=$( grep -E "^\s*LOC_N1\s+" $COMPILE_INFO_FILENAME | awk '{print $2}')
 LOC_N2=$( grep -E "^\s*LOC_N2\s+" $COMPILE_INFO_FILENAME | awk '{print $2}')
@@ -103,6 +104,7 @@ SIGMAGANG3=$( grep -E "^\s*SIGMAGANG3\s+" $COMPILE_INFO_FILENAME | awk '{print $
 
 COMMIT_HASH=$(git rev-parse HEAD)
 
+AC_DEFINE_UNQUOTED(NREPLICAS,   [[$NREPLICAS]])
 AC_DEFINE_UNQUOTED(LOC_N0,      [[$LOC_N0]])
 AC_DEFINE_UNQUOTED(LOC_N1,      [[$LOC_N1]])
 AC_DEFINE_UNQUOTED(LOC_N2,      [[$LOC_N2]])

--- a/doc/geom_defines.txt.example
+++ b/doc/geom_defines.txt.example
@@ -2,6 +2,8 @@
 # Please do not write things that can be mistaken for the 
 # tile parameters.
 
+NREPLICAS 1
+
 LOC_N0 32 
 LOC_N1 32 
 LOC_N2 32 

--- a/src/DbgTools/dbgtools.c
+++ b/src/DbgTools/dbgtools.c
@@ -430,7 +430,7 @@ int read_gl3_soa_wrapper(su3_soa * gl3, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - reading global gl3\n",devinfo.myrank );
         error = read_gl_gl3(conf_rw, nomefile);
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
         if(!error) {
             send_lnh_subconf_to_buffer(conf_rw,gl3,0);
@@ -448,7 +448,7 @@ int read_gl3_soa_wrapper(su3_soa * gl3, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - receiving gl3\n",devinfo.myrank );
 
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
         if(!error){ 
             receive_lnh_subconf_from_master(gl3);
         }
@@ -502,7 +502,7 @@ int read_vec3_soa_wrapper(vec3_soa * fermion, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - reading global fermion \n",devinfo.myrank );
         error = read_gl_fermion(ferm_rw, nomefile);
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
         if(!error) {
             send_lnh_subfermion_to_buffer(ferm_rw,fermion,0);
@@ -520,7 +520,7 @@ int read_vec3_soa_wrapper(vec3_soa * fermion, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - receiving fermion \n",devinfo.myrank );
 
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
         if(!error){ 
             receive_lnh_subfermion_from_master(fermion);
         }
@@ -573,7 +573,7 @@ int read_tamat_soa_wrapper(tamat_soa * tamat, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - reading global tamat\n",devinfo.myrank );
         error = read_gl_tamat(tamat_rw, nomefile);
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
         if(!error) {
             send_lnh_subtamat_to_buffer(tamat_rw,tamat,0);
@@ -591,7 +591,7 @@ int read_tamat_soa_wrapper(tamat_soa * tamat, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - receiving tamat\n",devinfo.myrank );
 
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
         if(!error){ 
             receive_lnh_subtamat_from_master(tamat);
         }
@@ -643,7 +643,7 @@ int read_thmat_soa_wrapper(thmat_soa * thmat, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - reading global thmat\n",devinfo.myrank );
         error = read_gl_thmat(thmat_rw, nomefile);
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
         if(!error) {
             send_lnh_subthmat_to_buffer(thmat_rw,thmat,0);
@@ -661,7 +661,7 @@ int read_thmat_soa_wrapper(thmat_soa * thmat, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - receiving thmat\n",devinfo.myrank );
 
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
         if(!error){ 
             receive_lnh_subthmat_from_master(thmat);
         }
@@ -712,7 +712,7 @@ int read_dcomplex_soa_wrapper(dcomplex_soa * dcarr, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - reading global dcarr\n",devinfo.myrank );
         error = read_gl_dcomplex(dcomplex_rw, nomefile);
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
         if(!error) {
             send_lnh_subdcomplex_to_buffer(dcomplex_rw,dcarr,0);
@@ -730,7 +730,7 @@ int read_dcomplex_soa_wrapper(dcomplex_soa * dcarr, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - receiving dcarr\n",devinfo.myrank );
 
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
         if(!error){ 
             receive_lnh_subdcomplex_from_master(dcarr);
         }
@@ -782,7 +782,7 @@ int read_double_soa_wrapper(double_soa * darr, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - reading global darr\n",devinfo.myrank );
         error = read_gl_double(double_rw, nomefile);
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
         if(!error) {
             send_lnh_subdouble_to_buffer(double_rw,darr,0);
@@ -800,7 +800,7 @@ int read_double_soa_wrapper(double_soa * darr, const char* nomefile)
         if(verbosity_lv > 2)
             printf("MPI%02d - receiving darr\n",devinfo.myrank );
 
-        MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
         if(!error){ 
             receive_lnh_subdouble_from_master(darr);
         }

--- a/src/Include/common_defines.h
+++ b/src/Include/common_defines.h
@@ -42,7 +42,11 @@
 // WARNING! uncomment only if you want to perform parallel tempering
 // ACHTUNG! Please, use script_compile_Open_StaPLE.sh to comment/uncomment this macro
 
+#ifdef NREPLICAS 
+#if NREPLICAS > 1
 #define PAR_TEMP
+#endif
+#endif
 
 #define STOUT_FERMIONS
 #ifdef STOUT_FERMIONS

--- a/src/Include/fermion_parameters.c
+++ b/src/Include/fermion_parameters.c
@@ -172,7 +172,7 @@ int rat_approx_file_or_script_create(RationalApprox* rational_approx){
 	char * nomefile = rational_approx_filename(rational_approx->error,rational_approx->exponent_num,rational_approx->exponent_den,rational_approx->lambda_min);
 
 #ifdef MULTIDEVICE
-	printf("MPI%02d - Some error happened in reading %s ...\n", devinfo.myrank,nomefile );
+	MPI_PRINTF1("- Some error happened in reading %s ...\n",nomefile);
 	if(0==devinfo.myrank){
 		FILE * bash_repair_commands = fopen("genappfiles.sh","a");
 

--- a/src/Include/fermion_parameters.c
+++ b/src/Include/fermion_parameters.c
@@ -191,7 +191,7 @@ int rat_approx_file_or_script_create(RationalApprox* rational_approx){
 						rational_approx->exponent_den, rational_approx->lambda_min);
 		fclose(bash_repair_commands);
 	}
-	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Barrier(devinfo.mpi_comm);
 	error_status = 1; // error cannot be corrected here.
 #else
 	char command[100];

--- a/src/Include/memory_wrapper.c
+++ b/src/Include/memory_wrapper.c
@@ -44,7 +44,7 @@ void free_wrapper(void *memptr)
   if(all==NULL)
     {
       fprintf(stderr,"\n  MPI%02d - Failed to find pointer %p in the list while freeing \n\n\n",devinfo.myrank,memptr);
-      MPI_Abort(devinfo.mpi_comm,0);
+      MPI_Abort(MPI_COMM_WORLD,0);
     }
   
   memory_used-=all->size;

--- a/src/Include/memory_wrapper.c
+++ b/src/Include/memory_wrapper.c
@@ -44,7 +44,7 @@ void free_wrapper(void *memptr)
   if(all==NULL)
     {
       fprintf(stderr,"\n  MPI%02d - Failed to find pointer %p in the list while freeing \n\n\n",devinfo.myrank,memptr);
-      MPI_Abort(MPI_COMM_WORLD,0);
+      MPI_Abort(devinfo.mpi_comm,0);
     }
   
   memory_used-=all->size;

--- a/src/Include/montecarlo_parameters.c
+++ b/src/Include/montecarlo_parameters.c
@@ -20,8 +20,7 @@ mc_params_t mc_params;
 
 void init_global_program_status(){
     
-	printf("MPI%02d: reading global program status  from file %s\n",
-				 devinfo.myrank, mc_params.statusFileName);
+	MPI_PRINTF1("reading global program status  from file %s\n", mc_params.statusFileName);
 
 	FILE * gps_file = fopen(mc_params.statusFileName, "r");  
 	if(gps_file){

--- a/src/Include/montecarlo_parameters.c
+++ b/src/Include/montecarlo_parameters.c
@@ -40,8 +40,7 @@ void init_global_program_status(){
 	}
 	else 
     {
-			printf("MPI%02d: file %s not readable\n",
-						 devinfo.myrank, mc_params.statusFileName);
+			MPI_PRINTF1("file %s not readable\n", mc_params.statusFileName);
 
 			mc_params.next_gps  = GPSTATUS_UPDATE;
 			mc_params.max_flavour_cycle_time = 1.0f;

--- a/src/Include/rep_info.h
+++ b/src/Include/rep_info.h
@@ -7,7 +7,6 @@ typedef struct rep_info_t {
 	int defect_coordinates[3];
 	double *cr_vec;
 	int *label;
-//	int *inv_label; //TODO: maybe necessary for swaps
 } rep_info;
 extern rep_info *rep;
 

--- a/src/Include/rep_info.h
+++ b/src/Include/rep_info.h
@@ -7,6 +7,7 @@ typedef struct rep_info_t {
 	int defect_coordinates[3];
 	double *cr_vec;
 	int *label;
+//	int *inv_label; //TODO: maybe necessary for swaps
 } rep_info;
 extern rep_info *rep;
 

--- a/src/Include/setting_file_parser.c
+++ b/src/Include/setting_file_parser.c
@@ -673,7 +673,7 @@ int read_device_setting(dev_info * di,char filelines[MAXLINES][MAXLINELENGTH], i
 	const char nranks_read_comment[] = "# NRanks has been set at make time with the NR3 variable.";
 
 	par_info tp[]= {
-#ifndef MULTIDEVICE        
+#if !(NRANKS_D3 > 1)
 									(par_info){(void*) &(di->single_dev_choice),TYPE_INT,"device_choice",    NULL,                                 NULL},
 									(par_info){(void*) IGNORE_IT,               TYPE_INT,"AsyncFermionComms",(const void*) &async_comm_fermion_def,NULL},
 									(par_info){(void*) IGNORE_IT,               TYPE_INT,"AsyncGaugeComms",  (const void*) &async_comm_gauge_def,  NULL},

--- a/src/Include/setting_file_parser.c
+++ b/src/Include/setting_file_parser.c
@@ -691,7 +691,7 @@ int read_device_setting(dev_info * di,char filelines[MAXLINES][MAXLINELENGTH], i
 	if(!helpmode){
 #ifdef MULTIDEVICE
 		if(di->nranks_read != di->nranks){
-			printf("MPI%02d: ERROR: nranks from settings file ", di->myrank);
+			MPI_PRINTF0("ERROR: nranks from settings file ");
 			printf("and from MPI_Init() DIFFER!\n");
 			printf("settings: %d , MPI_Init(): %d\n",
 						 di->nranks_read, di->nranks);
@@ -909,7 +909,7 @@ int set_global_vars_and_fermions_from_input_file(const char* input_filename)
 	char filelines[MAXLINES][MAXLINELENGTH];
 	FILE *input = fopen(input_filename,"r");
 	if (input == NULL){
-		printf("MPI%02d: Could not open file %s \n",devinfo.myrank,input_filename );
+		MPI_PRINTF1("Could not open file %s \n",input_filename);
 		if(0==devinfo.myrank){
 			printf("Creating a template inputfile\n" );
 		}
@@ -1112,7 +1112,7 @@ int set_global_vars_and_fermions_from_input_file(const char* input_filename)
 
 		if(0==devinfo.myrank && totcheck )
 			printf("There are errors in some groups, exiting.\n");
-		printf("MPI%02d: Returning error 1...\n",devinfo.myrank);
+		MPI_PRINTF0("Returning error 1...\n");
 		return 1;
 
 	}

--- a/src/Include/setting_file_parser.c
+++ b/src/Include/setting_file_parser.c
@@ -790,6 +790,7 @@ int read_replicas_numbers(rep_info * re,char filelines[MAXLINES][MAXLINELENGTH],
 #ifndef PAR_TEMP
 	re->replicas_total_number = 1;
 	alloc_info.num_replicas = re->replicas_total_number;
+	re->label=malloc(alloc_info.num_replicas*sizeof(int));
 #else      
 	alloc_info.num_replicas=re->replicas_total_number;
 	par_info rp1[3];

--- a/src/Include/setting_file_parser.c
+++ b/src/Include/setting_file_parser.c
@@ -846,6 +846,14 @@ int read_replicas_numbers(rep_info * re,char filelines[MAXLINES][MAXLINELENGTH],
 		res=1;
 	}
 
+	// check number of replicas as in geom defines
+	if(re->replicas_total_number != NREPLICAS){
+		printf("ERROR: NREPLICAS in geom_defines does not match the value totalnumber in input file\n");
+		printf("NREPLICAS=%d, totalnumber=%d\n",NREPLICAS, re->replicas_total_number);
+		res=1;
+	}
+
+
 	// check that defect length is smaller than lattice size along the corresponding direction	
 	int perp_dir[4][3] = { {1, 2, 3}, {0, 2, 3}, {0, 1, 3}, {0, 1, 2} };
 	int lat_size[4];

--- a/src/Include/setting_file_parser.c
+++ b/src/Include/setting_file_parser.c
@@ -673,7 +673,7 @@ int read_device_setting(dev_info * di,char filelines[MAXLINES][MAXLINELENGTH], i
 	const char nranks_read_comment[] = "# NRanks has been set at make time with the NR3 variable.";
 
 	par_info tp[]= {
-#if !(NRANKS_D3 > 1)
+#ifndef MULTIDEVICE
 									(par_info){(void*) &(di->single_dev_choice),TYPE_INT,"device_choice",    NULL,                                 NULL},
 									(par_info){(void*) IGNORE_IT,               TYPE_INT,"AsyncFermionComms",(const void*) &async_comm_fermion_def,NULL},
 									(par_info){(void*) IGNORE_IT,               TYPE_INT,"AsyncGaugeComms",  (const void*) &async_comm_gauge_def,  NULL},

--- a/src/Include/tell_geom_defines.c
+++ b/src/Include/tell_geom_defines.c
@@ -6,6 +6,7 @@ void print_geom_defines(){
 	printf("#############################\n") ;
 	printf("#   PRINTING GEOM DEFINES   #\n") ;
 	printf("#############################\n") ;
+	printf("NREPLICAS    %d\n",NREPLICAS     );         
 	printf("LOC_N0       %d\n",LOC_N0       );         
 	printf("LOC_N1       %d\n",LOC_N1       );         
 	printf("LOC_N2       %d\n",LOC_N2       );         

--- a/src/Meas/baryon_number_utilities.c
+++ b/src/Meas/baryon_number_utilities.c
@@ -64,7 +64,7 @@ void dM_dmu_eo0( __restrict const su3_soa * u,
         } // Loop over nd2
     } // Loop over nd3
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 
@@ -121,7 +121,7 @@ void dM_dmu_eo1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -177,7 +177,7 @@ void dM_dmu_eo2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -233,7 +233,7 @@ void dM_dmu_eo3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -295,7 +295,7 @@ void dM_dmu_oe0( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -350,7 +350,7 @@ void dM_dmu_oe1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -405,7 +405,7 @@ void dM_dmu_oe2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -460,7 +460,7 @@ void dM_dmu_oe3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -525,7 +525,7 @@ void d2M_dmu2_eo0( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -581,7 +581,7 @@ void d2M_dmu2_eo1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -637,7 +637,7 @@ void d2M_dmu2_eo2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -693,7 +693,7 @@ void d2M_dmu2_eo3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -755,7 +755,7 @@ void d2M_dmu2_oe0( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -810,7 +810,7 @@ void d2M_dmu2_oe1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -865,7 +865,7 @@ void d2M_dmu2_oe2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }
@@ -920,7 +920,7 @@ void d2M_dmu2_oe3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_fermion_borders(out);
 #endif
 }

--- a/src/Meas/baryon_number_utilities.c
+++ b/src/Meas/baryon_number_utilities.c
@@ -64,7 +64,7 @@ void dM_dmu_eo0( __restrict const su3_soa * u,
         } // Loop over nd2
     } // Loop over nd3
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 
@@ -121,7 +121,7 @@ void dM_dmu_eo1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -177,7 +177,7 @@ void dM_dmu_eo2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -233,7 +233,7 @@ void dM_dmu_eo3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -295,7 +295,7 @@ void dM_dmu_oe0( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -350,7 +350,7 @@ void dM_dmu_oe1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -405,7 +405,7 @@ void dM_dmu_oe2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -460,7 +460,7 @@ void dM_dmu_oe3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -525,7 +525,7 @@ void d2M_dmu2_eo0( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -581,7 +581,7 @@ void d2M_dmu2_eo1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -637,7 +637,7 @@ void d2M_dmu2_eo2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -693,7 +693,7 @@ void d2M_dmu2_eo3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -755,7 +755,7 @@ void d2M_dmu2_oe0( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -810,7 +810,7 @@ void d2M_dmu2_oe1( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -865,7 +865,7 @@ void d2M_dmu2_oe2( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }
@@ -920,7 +920,7 @@ void d2M_dmu2_oe3( __restrict const su3_soa * u,
             } // Loop over nd1
         } // Loop over nd2
     } // Loop over nd3
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_fermion_borders(out);
 #endif
 }

--- a/src/Meas/ferm_meas.c
+++ b/src/Meas/ferm_meas.c
@@ -131,7 +131,7 @@ void set_fermion_file_header(ferm_meas_params * fmpar, ferm_param * tferm_par){
 
 }
 
-void fermion_measures( su3_soa * tconf_acc,
+void fermion_measures(su3_soa * tconf_acc,
         ferm_param * tfermions_parameters,
         ferm_meas_params * tfm_par,
         double res, int max_cg, int conf_id_iter,
@@ -160,8 +160,10 @@ void fermion_measures( su3_soa * tconf_acc,
 #else
     conf_to_use = tconf_acc;
 #endif
+
     if(inverter_tricks.useMixedPrecision){ 
-        conf_to_use_f = conf_acc_f[0];// global variable
+//        conf_to_use_f = conf_acc_f[0];// global variable
+        conf_to_use_f = conf_acc_f;// global variable
         convert_double_to_float_su3_soa(conf_to_use,conf_to_use_f); 
     }
 

--- a/src/Meas/ferm_meas.c
+++ b/src/Meas/ferm_meas.c
@@ -488,7 +488,7 @@ void fermion_measures( su3_soa * tconf_acc,
 
 
 #ifdef MULTIDEVICE
-	    MPI_Bcast((void*)&(mc_params.run_condition),1,MPI_INT,0,MPI_COMM_WORLD);
+	    MPI_Bcast((void*)&(mc_params.run_condition),1,MPI_INT,0,devinfo.mpi_comm);
 	    printf("MPI%02d - Broadcast of run condition %d from master...\n",
 			    devinfo.myrank, mc_params.run_condition);
 #endif

--- a/src/Meas/gauge_meas.c
+++ b/src/Meas/gauge_meas.c
@@ -153,7 +153,7 @@ double reduce_loc_top_charge(double_soa * const loc_q)
 
 #ifdef MULTIDEVICE
   double partial = result;
-  MPI_Allreduce((void*)&partial,(void*)&result,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+  MPI_Allreduce((void*)&partial,(void*)&result,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 
 #endif
     return result;

--- a/src/Meas/gauge_meas.c
+++ b/src/Meas/gauge_meas.c
@@ -151,7 +151,7 @@ double reduce_loc_top_charge(double_soa * const loc_q)
         result += loc_q[1].d[t];
     }
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
   double partial = result;
   MPI_Allreduce((void*)&partial,(void*)&result,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 

--- a/src/Meas/gauge_meas.c
+++ b/src/Meas/gauge_meas.c
@@ -151,7 +151,7 @@ double reduce_loc_top_charge(double_soa * const loc_q)
         result += loc_q[1].d[t];
     }
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
   double partial = result;
   MPI_Allreduce((void*)&partial,(void*)&result,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 

--- a/src/Meas/polyakov.c
+++ b/src/Meas/polyakov.c
@@ -21,7 +21,7 @@
 
 // For Polyakov loop calculations
 #define ALIGN 128
-#ifdef MULTIDEVICE
+#ifdef NRANKS_D3 > 1
 #define vol30h LOC_VOL4/LOC_N0/2 
 #define vol31h LOC_VOL4/LOC_N1/2 
 #define vol32h LOC_VOL4/LOC_N2/2 
@@ -204,7 +204,7 @@ d_complex polyakov_loop0(__restrict const su3_soa * const u)
     free(loopplk0);
 
     double trr,tri;
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
@@ -288,7 +288,7 @@ d_complex polyakov_loop1(__restrict const su3_soa * const u)
     free(loopplk1);
 
     double trr,tri;
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
@@ -370,7 +370,7 @@ d_complex polyakov_loop2(__restrict const su3_soa * const u)
 
 
     double trr,tri;
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
@@ -453,7 +453,7 @@ d_complex polyakov_loop3(__restrict const su3_soa * const u)
     free(loopplk3);
 
     double trr,tri;
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,

--- a/src/Meas/polyakov.c
+++ b/src/Meas/polyakov.c
@@ -206,9 +206,9 @@ d_complex polyakov_loop0(__restrict const su3_soa * const u)
     double trr,tri;
 #ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
      trr = rel;
      tri = iml;
@@ -290,9 +290,9 @@ d_complex polyakov_loop1(__restrict const su3_soa * const u)
     double trr,tri;
 #ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
      trr = rel;
      tri = iml;
@@ -372,9 +372,9 @@ d_complex polyakov_loop2(__restrict const su3_soa * const u)
     double trr,tri;
 #ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
      trr = rel;
      tri = iml;
@@ -455,9 +455,9 @@ d_complex polyakov_loop3(__restrict const su3_soa * const u)
     double trr,tri;
 #ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
-             1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+             1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
      trr = rel;
      tri = iml;

--- a/src/Meas/polyakov.c
+++ b/src/Meas/polyakov.c
@@ -204,7 +204,7 @@ d_complex polyakov_loop0(__restrict const su3_soa * const u)
     free(loopplk0);
 
     double trr,tri;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
@@ -288,7 +288,7 @@ d_complex polyakov_loop1(__restrict const su3_soa * const u)
     free(loopplk1);
 
     double trr,tri;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
@@ -370,7 +370,7 @@ d_complex polyakov_loop2(__restrict const su3_soa * const u)
 
 
     double trr,tri;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,
@@ -453,7 +453,7 @@ d_complex polyakov_loop3(__restrict const su3_soa * const u)
     free(loopplk3);
 
     double trr,tri;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
      MPI_Allreduce((void*)&rel,(void*)&trr,
              1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
      MPI_Allreduce((void*)&iml,(void*)&tri,

--- a/src/Mpi/communications.c
+++ b/src/Mpi/communications.c
@@ -76,7 +76,7 @@ void sendrecv_vec3soa_borders_1Dcut(vec3_soa *lnh_fermion,
                     rankL,sendtag,
                     (void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,MPI_DOUBLE,
                     rankR,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[(sizeh-offset_size):slab_sizeh])
 #endif
@@ -93,7 +93,7 @@ void sendrecv_vec3soa_borders_1Dcut(vec3_soa *lnh_fermion,
                     (void*) &(c[ii][offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
                     rankL,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[offset_size-slab_sizeh:slab_sizeh])
 #endif
@@ -139,7 +139,7 @@ void sendrecv_vec3soa_borders_1Dcut_hostonly(vec3_soa *lnh_fermion,
                 rankL,sendtag,
                 (void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,MPI_DOUBLE,
                 rankR,recvtag,
-                MPI_COMM_WORLD, &status);
+                devinfo.mpi_comm, &status);
 
         sendtag = ii+3;
         recvtag = ii+3;
@@ -150,7 +150,7 @@ void sendrecv_vec3soa_borders_1Dcut_hostonly(vec3_soa *lnh_fermion,
                 (void*) &(c[ii][offset_size-slab_sizeh]),
                 2*slab_sizeh,MPI_DOUBLE,
                 rankL,recvtag,
-                MPI_COMM_WORLD, &status);
+                devinfo.mpi_comm, &status);
     }
 
 }
@@ -159,11 +159,11 @@ void communicate_fermion_borders(vec3_soa *lnh_fermion) // WRAPPER
 {
 
     // NOTICE: GEOMETRY MUST BE SET UP BEFORE!!
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(devinfo.mpi_comm);
     sendrecv_vec3soa_borders_1Dcut(lnh_fermion,
             devinfo.myrank_L, devinfo.myrank_R, 
             FERMION_HALO);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(devinfo.mpi_comm);
 }
 
 
@@ -172,12 +172,12 @@ void communicate_fermion_borders_hostonly(vec3_soa *lnh_fermion) // WRAPPER
 {
 
     // NOTICE: GEOMETRY MUST BE SET UP BEFORE!!
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(devinfo.mpi_comm);
 
     sendrecv_vec3soa_borders_1Dcut_hostonly(lnh_fermion,
             devinfo.myrank_L, devinfo.myrank_R, 
             FERMION_HALO);
-    MPI_Barrier(MPI_COMM_WORLD);
+    MPI_Barrier(devinfo.mpi_comm);
 }
 
 
@@ -230,11 +230,11 @@ void sendrecv_vec3soa_borders_1Dcut_async(vec3_soa *lnh_fermion,
 
             d_complex *tmpc = c[ii];
             MPI_Isend((void*) &(c[ii][offset_size]),2*slab_sizeh,MPI_DOUBLE,
-                    rankL,sendtag,MPI_COMM_WORLD,
+                    rankL,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[ii]));
             MPI_Irecv((void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,
                     MPI_DOUBLE,
-                    rankR,recvtag,MPI_COMM_WORLD,
+                    rankR,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[ii]));
 
 
@@ -243,11 +243,11 @@ void sendrecv_vec3soa_borders_1Dcut_async(vec3_soa *lnh_fermion,
 
             MPI_Isend((void*) &(c[ii][sizeh-offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
-                    rankR,sendtag,MPI_COMM_WORLD,
+                    rankR,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[3+ii]));
             MPI_Irecv( (void*) &(c[ii][offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
-                    rankL,recvtag,MPI_COMM_WORLD,
+                    rankL,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[3+ii]));
 
         }
@@ -401,7 +401,7 @@ void sendrecv_thmat_soa_borders_1Dcut(thmat_soa *lnh_momenta,
                     rankL,sendtag,
                     (void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,MPI_DOUBLE,
                     rankR,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[(sizeh-offset_size):slab_sizeh])
 #endif
@@ -418,7 +418,7 @@ void sendrecv_thmat_soa_borders_1Dcut(thmat_soa *lnh_momenta,
                     (void*) &(c[ii][offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
                     rankL,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[offset_size-slab_sizeh:slab_sizeh])
 #endif
@@ -439,7 +439,7 @@ void sendrecv_thmat_soa_borders_1Dcut(thmat_soa *lnh_momenta,
                     rankL,sendtag,
                     (void*) &(cd[ii][sizeh-offset_size]),slab_sizeh,MPI_DOUBLE,
                     rankR,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[(sizeh-offset_size):slab_sizeh])
 #endif
@@ -456,7 +456,7 @@ void sendrecv_thmat_soa_borders_1Dcut(thmat_soa *lnh_momenta,
                     (void*) &(cd[ii][offset_size-slab_sizeh]),
                     slab_sizeh,MPI_DOUBLE,
                     rankL,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[offset_size-slab_sizeh:slab_sizeh])
 #endif
@@ -508,11 +508,11 @@ void sendrecv_thmat_soa_borders_1Dcut_async(thmat_soa *lnh_momenta,
 
             d_complex *tmpc = c[ii];
             MPI_Isend((void*) &(c[ii][offset_size]),2*slab_sizeh,MPI_DOUBLE,
-                    rankL,sendtag,MPI_COMM_WORLD,
+                    rankL,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[ii]));
             MPI_Irecv((void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,
                     MPI_DOUBLE,
-                    rankR,recvtag,MPI_COMM_WORLD,
+                    rankR,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[ii]));
 
 
@@ -521,11 +521,11 @@ void sendrecv_thmat_soa_borders_1Dcut_async(thmat_soa *lnh_momenta,
 
             MPI_Isend((void*) &(c[ii][sizeh-offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
-                    rankR,sendtag,MPI_COMM_WORLD,
+                    rankR,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[3+ii]));
             MPI_Irecv( (void*) &(c[ii][offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
-                    rankL,recvtag,MPI_COMM_WORLD,
+                    rankL,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[3+ii]));
 
         }
@@ -537,11 +537,11 @@ void sendrecv_thmat_soa_borders_1Dcut_async(thmat_soa *lnh_momenta,
 
             double *tmpc = cd[ii];
             MPI_Isend((void*) &(cd[ii][offset_size]),slab_sizeh,MPI_DOUBLE,
-                    rankL,sendtag,MPI_COMM_WORLD,
+                    rankL,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[6+ii]));
             MPI_Irecv((void*) &(cd[ii][sizeh-offset_size]),slab_sizeh,
                     MPI_DOUBLE,
-                    rankR,recvtag,MPI_COMM_WORLD,
+                    rankR,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[6+ii]));
 
 
@@ -550,11 +550,11 @@ void sendrecv_thmat_soa_borders_1Dcut_async(thmat_soa *lnh_momenta,
 
             MPI_Isend((void*) &(cd[ii][sizeh-offset_size-slab_sizeh]),
                     slab_sizeh,MPI_DOUBLE,
-                    rankR,sendtag,MPI_COMM_WORLD,
+                    rankR,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[8+ii]));
             MPI_Irecv( (void*) &(cd[ii][offset_size-slab_sizeh]),
                     slab_sizeh,MPI_DOUBLE,
-                    rankL,recvtag,MPI_COMM_WORLD,
+                    rankL,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[8+ii]));
 
         }
@@ -607,7 +607,7 @@ void sendrecv_tamat_soa_borders_1Dcut(tamat_soa *lnh_ipdot,
                     rankL,sendtag,
                     (void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,MPI_DOUBLE,
                     rankR,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[(sizeh-offset_size):slab_sizeh])
 #endif
@@ -624,7 +624,7 @@ void sendrecv_tamat_soa_borders_1Dcut(tamat_soa *lnh_ipdot,
                     (void*) &(c[ii][offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
                     rankL,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[offset_size-slab_sizeh:slab_sizeh])
 #endif
@@ -643,7 +643,7 @@ void sendrecv_tamat_soa_borders_1Dcut(tamat_soa *lnh_ipdot,
                     rankL,sendtag,
                     (void*) &(cd[ii][sizeh-offset_size]),slab_sizeh,MPI_DOUBLE,
                     rankR,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[(sizeh-offset_size):slab_sizeh])
 #endif
@@ -660,7 +660,7 @@ void sendrecv_tamat_soa_borders_1Dcut(tamat_soa *lnh_ipdot,
                     (void*) &(cd[ii][offset_size-slab_sizeh]),
                     slab_sizeh,MPI_DOUBLE,
                     rankL,recvtag,
-                    MPI_COMM_WORLD, &status);
+                    devinfo.mpi_comm, &status);
 #ifndef USE_MPI_CUDA_AWARE
 #pragma acc update device(tmpc[offset_size-slab_sizeh:slab_sizeh])
 #endif
@@ -711,11 +711,11 @@ void sendrecv_tamat_soa_borders_1Dcut_async(tamat_soa *lnh_ipdot,
 
             d_complex *tmpc = c[ii];
             MPI_Isend((void*) &(c[ii][offset_size]),2*slab_sizeh,MPI_DOUBLE,
-                    rankL,sendtag,MPI_COMM_WORLD,
+                    rankL,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[ii]));
             MPI_Irecv((void*) &(c[ii][sizeh-offset_size]),2*slab_sizeh,
                     MPI_DOUBLE,
-                    rankR,recvtag,MPI_COMM_WORLD,
+                    rankR,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[ii]));
 
 
@@ -724,11 +724,11 @@ void sendrecv_tamat_soa_borders_1Dcut_async(tamat_soa *lnh_ipdot,
 
             MPI_Isend((void*) &(c[ii][sizeh-offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
-                    rankR,sendtag,MPI_COMM_WORLD,
+                    rankR,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[3+ii]));
             MPI_Irecv( (void*) &(c[ii][offset_size-slab_sizeh]),
                     2*slab_sizeh,MPI_DOUBLE,
-                    rankL,recvtag,MPI_COMM_WORLD,
+                    rankL,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[3+ii]));
 
         }
@@ -740,11 +740,11 @@ void sendrecv_tamat_soa_borders_1Dcut_async(tamat_soa *lnh_ipdot,
 
             double *tmpc = cd[ii];
             MPI_Isend((void*) &(cd[ii][offset_size]),slab_sizeh,MPI_DOUBLE,
-                    rankL,sendtag,MPI_COMM_WORLD,
+                    rankL,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[6+ii]));
             MPI_Irecv((void*) &(cd[ii][sizeh-offset_size]),slab_sizeh,
                     MPI_DOUBLE,
-                    rankR,recvtag,MPI_COMM_WORLD,
+                    rankR,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[6+ii]));
 
 
@@ -753,11 +753,11 @@ void sendrecv_tamat_soa_borders_1Dcut_async(tamat_soa *lnh_ipdot,
 
             MPI_Isend((void*) &(cd[ii][sizeh-offset_size-slab_sizeh]),
                     slab_sizeh,MPI_DOUBLE,
-                    rankR,sendtag,MPI_COMM_WORLD,
+                    rankR,sendtag,devinfo.mpi_comm,
                     &(send_border_requests[8+ii]));
             MPI_Irecv( (void*) &(cd[ii][offset_size-slab_sizeh]),
                     slab_sizeh,MPI_DOUBLE,
-                    rankL,recvtag,MPI_COMM_WORLD,
+                    rankL,recvtag,devinfo.mpi_comm,
                     &(recv_border_requests[8+ii]));
 
         }
@@ -838,12 +838,12 @@ void send_lnh_subconf_to_rank(const global_su3_soa *gl_soa_conf,
     //sending the subconfiguration
     //
     // OLD LINE
-    //MPI_Send(target_su3_soa, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE, target_rank , target_rank, MPI_COMM_WORLD); // tag = target_rank
+    //MPI_Send(target_su3_soa, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE, target_rank , target_rank, devinfo.mpi_comm); // tag = target_rank
     
-		MPI_Send(target_su3_soa, 8*sizeof(su3_soa), MPI_CHAR, target_rank, target_rank, MPI_COMM_WORLD); // tag = target_rank
+		MPI_Send(target_su3_soa, 8*sizeof(su3_soa), MPI_CHAR, target_rank, target_rank, devinfo.mpi_comm); // tag = target_rank
 
 		// In case we remove the third line, this is possibly the thing to do
-    //MPI_Send(target_su3_soa, 2*4*(6*2)*LNH_SIZEH,MPI_DOUBLE, rank, 0, MPI_COMM_WORLD);
+    //MPI_Send(target_su3_soa, 2*4*(6*2)*LNH_SIZEH,MPI_DOUBLE, rank, 0, devinfo.mpi_comm);
     //Or maybe do multiple sends in a more complicated way
     // ^^ CHECK
     FREECHECK(target_su3_soa);
@@ -874,10 +874,10 @@ void recv_loc_subconf_from_rank(global_su3_soa *gl_soa_conf,
     ALLOCCHECK(allocation_check, target_su3_soa);
 
     // OLD LINE
-		//MPI_Recv(target_su3_soa, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE,target_rank,tag,MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+		//MPI_Recv(target_su3_soa, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE,target_rank,tag,devinfo.mpi_comm, MPI_STATUS_IGNORE);
 
 
-		MPI_Recv(target_su3_soa, 8*sizeof(su3_soa), MPI_CHAR, target_rank,tag,MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+		MPI_Recv(target_su3_soa, 8*sizeof(su3_soa), MPI_CHAR, target_rank,tag,devinfo.mpi_comm, MPI_STATUS_IGNORE);
 
     recv_loc_subconf_from_buffer(gl_soa_conf,target_su3_soa,target_rank);
 
@@ -890,18 +890,18 @@ void send_lnh_subconf_to_master(const su3_soa *lnh_soa_conf, int tag)
            devinfo.myrank,tag);
 		
 		// OLD LINE vvv
-    //MPI_Send(lnh_soa_conf, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE, 0, tag , MPI_COMM_WORLD);
+    //MPI_Send(lnh_soa_conf, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE, 0, tag , devinfo.mpi_comm);
 		
 		// NEW LINE vvv
-		MPI_Send(lnh_soa_conf, 8*sizeof(su3_soa), MPI_CHAR, 0, tag, MPI_COMM_WORLD);
+		MPI_Send(lnh_soa_conf, 8*sizeof(su3_soa), MPI_CHAR, 0, tag, devinfo.mpi_comm);
 }
 void receive_lnh_subconf_from_master(su3_soa* lnh_su3_conf)
 {
 		// OLD LINE vvv
-    //MPI_Recv(lnh_su3_conf, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE,0, devinfo.myrank,MPI_COMM_WORLD, MPI_STATUS_IGNORE); // tag = myrank
+    //MPI_Recv(lnh_su3_conf, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE,0, devinfo.myrank,devinfo.mpi_comm, MPI_STATUS_IGNORE); // tag = myrank
 
 		// NEW LINE vvv
-    MPI_Recv(lnh_su3_conf, 8*sizeof(su3_soa), MPI_CHAR, 0, devinfo.myrank,MPI_COMM_WORLD, MPI_STATUS_IGNORE); // tag = myrank
+    MPI_Recv(lnh_su3_conf, 8*sizeof(su3_soa), MPI_CHAR, 0, devinfo.myrank,devinfo.mpi_comm, MPI_STATUS_IGNORE); // tag = myrank
 
     // In case we remove the third line possibly 
     // we have to do something different
@@ -918,7 +918,7 @@ void send_lnh_subfermion_to_rank(const global_vec3_soa *gl_soa_ferm,
     ALLOCCHECK(allocation_check, lnh_ferm);
     send_lnh_subfermion_to_buffer(gl_soa_ferm,lnh_ferm,target_rank);
     MPI_Send(lnh_ferm, 6*LNH_SIZEH,MPI_DOUBLE, target_rank , target_rank,
-            MPI_COMM_WORLD); // tag = target_rank
+            devinfo.mpi_comm); // tag = target_rank
 
     FREECHECK(lnh_ferm);
 }
@@ -931,7 +931,7 @@ void recv_loc_subfermion_from_rank(global_vec3_soa *gl_soa_ferm,
     ALLOCCHECK(allocation_check, lnh_ferm);
 
     MPI_Recv(lnh_ferm, 6*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            devinfo.mpi_comm, MPI_STATUS_IGNORE);
 
     recv_loc_subfermion_from_buffer(gl_soa_ferm, lnh_ferm, target_rank);
 
@@ -943,12 +943,12 @@ void recv_loc_subfermion_from_rank(global_vec3_soa *gl_soa_ferm,
 void send_lnh_subfermion_to_master(const vec3_soa *lnh_ferm, int tag)
 {
     MPI_Send(lnh_ferm, 6*LNH_SIZEH,MPI_DOUBLE,0,tag           ,
-            MPI_COMM_WORLD); // tag = myrank
+            devinfo.mpi_comm); // tag = myrank
 }
 void receive_lnh_subfermion_from_master(vec3_soa* lnh_ferm)
 {
     MPI_Recv(lnh_ferm, 6*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,
-            MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            devinfo.mpi_comm, MPI_STATUS_IGNORE);
 }
 
 // chunks, tamats
@@ -961,7 +961,7 @@ void send_lnh_subtamat_to_rank(const global_tamat_soa *gl_soa_tamat,
     ALLOCCHECK(allocation_check,lnh_tamat);
     send_lnh_subtamat_to_buffer(gl_soa_tamat,lnh_tamat,target_rank);
     MPI_Send(lnh_tamat,8*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD);
+            devinfo.mpi_comm);
     FREECHECK(lnh_tamat);
 
 }
@@ -972,18 +972,18 @@ void recv_loc_subtamat_from_rank(global_tamat_soa *gl_soa_tamat,
             sizeof(tamat_soa)); 
     ALLOCCHECK(allocation_check,lnh_tamat);
     MPI_Recv(lnh_tamat,8*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+            devinfo.mpi_comm,MPI_STATUS_IGNORE);
     recv_loc_subtamat_from_buffer(gl_soa_tamat,lnh_tamat,target_rank);
     FREECHECK(lnh_tamat);
 
 }
 void send_lnh_subtamat_to_master(const tamat_soa *lnh_tamat, int tag){
 
-    MPI_Send(lnh_tamat,8*LNH_SIZEH,MPI_DOUBLE,0,tag,MPI_COMM_WORLD);
+    MPI_Send(lnh_tamat,8*LNH_SIZEH,MPI_DOUBLE,0,tag,devinfo.mpi_comm);
 
 }
 void receive_lnh_subtamat_from_master(tamat_soa* lnh_tamat){
-    MPI_Recv(lnh_tamat,8*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,MPI_COMM_WORLD,
+    MPI_Recv(lnh_tamat,8*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,devinfo.mpi_comm,
             MPI_STATUS_IGNORE);
 }
 
@@ -997,7 +997,7 @@ void send_lnh_subthmat_to_rank(const global_thmat_soa *gl_soa_thmat,
     ALLOCCHECK(allocation_check,lnh_thmat);
     send_lnh_subthmat_to_buffer(gl_soa_thmat,lnh_thmat,target_rank);
     MPI_Send(lnh_thmat,8*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD);
+            devinfo.mpi_comm);
     FREECHECK(lnh_thmat);
 
 }
@@ -1008,18 +1008,18 @@ void recv_loc_subthmat_from_rank(global_thmat_soa *gl_soa_thmat,
             sizeof(thmat_soa)); 
     ALLOCCHECK(allocation_check,lnh_thmat);
     MPI_Recv(lnh_thmat,8*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+            devinfo.mpi_comm,MPI_STATUS_IGNORE);
     recv_loc_subthmat_from_buffer(gl_soa_thmat,lnh_thmat,target_rank);
     FREECHECK(lnh_thmat);
 
 }
 void send_lnh_subthmat_to_master(const thmat_soa *lnh_thmat, int tag){
 
-    MPI_Send(lnh_thmat,8*LNH_SIZEH,MPI_DOUBLE,0,tag,MPI_COMM_WORLD);
+    MPI_Send(lnh_thmat,8*LNH_SIZEH,MPI_DOUBLE,0,tag,devinfo.mpi_comm);
 
 }
 void receive_lnh_subthmat_from_master(thmat_soa* lnh_thmat){
-    MPI_Recv(lnh_thmat,8*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,MPI_COMM_WORLD,
+    MPI_Recv(lnh_thmat,8*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,devinfo.mpi_comm,
             MPI_STATUS_IGNORE);
 }
 
@@ -1033,7 +1033,7 @@ void send_lnh_subdcomplex_to_rank(const global_dcomplex_soa *gl_soa_dcomplex,
     ALLOCCHECK(allocation_check,lnh_dcomplex);
     send_lnh_subdcomplex_to_buffer(gl_soa_dcomplex,lnh_dcomplex,target_rank);
     MPI_Send(lnh_dcomplex,2*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD);
+            devinfo.mpi_comm);
     FREECHECK(lnh_dcomplex);
 
 }
@@ -1044,18 +1044,18 @@ void recv_loc_subdcomplex_from_rank(global_dcomplex_soa *gl_soa_dcomplex,
             sizeof(dcomplex_soa)); 
     ALLOCCHECK(allocation_check,lnh_dcomplex);
     MPI_Recv(lnh_dcomplex,2*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+            devinfo.mpi_comm,MPI_STATUS_IGNORE);
     recv_loc_subdcomplex_from_buffer(gl_soa_dcomplex,lnh_dcomplex,target_rank);
     FREECHECK(lnh_dcomplex);
 
 }
 void send_lnh_subdcomplex_to_master(const dcomplex_soa *lnh_dcomplex, int tag){
 
-    MPI_Send(lnh_dcomplex,2*LNH_SIZEH,MPI_DOUBLE,0,tag,MPI_COMM_WORLD);
+    MPI_Send(lnh_dcomplex,2*LNH_SIZEH,MPI_DOUBLE,0,tag,devinfo.mpi_comm);
 
 }
 void receive_lnh_subdcomplex_from_master(dcomplex_soa* lnh_dcomplex){
-    MPI_Recv(lnh_dcomplex,2*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,MPI_COMM_WORLD,
+    MPI_Recv(lnh_dcomplex,2*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,devinfo.mpi_comm,
             MPI_STATUS_IGNORE);
 }
 
@@ -1069,7 +1069,7 @@ void send_lnh_subdouble_to_rank(const global_double_soa *gl_soa_double,
     ALLOCCHECK(allocation_check,lnh_double);
     send_lnh_subdouble_to_buffer(gl_soa_double,lnh_double,target_rank);
     MPI_Send(lnh_double,1*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD);
+            devinfo.mpi_comm);
     FREECHECK(lnh_double);
 
 }
@@ -1080,18 +1080,18 @@ void recv_loc_subdouble_from_rank(global_double_soa *gl_soa_double,
             sizeof(double_soa)); 
     ALLOCCHECK(allocation_check,lnh_double);
     MPI_Recv(lnh_double,1*LNH_SIZEH,MPI_DOUBLE,target_rank,target_rank,
-            MPI_COMM_WORLD,MPI_STATUS_IGNORE);
+            devinfo.mpi_comm,MPI_STATUS_IGNORE);
     recv_loc_subdouble_from_buffer(gl_soa_double,lnh_double,target_rank);
     FREECHECK(lnh_double);
 
 }
 void send_lnh_subdouble_to_master(const double_soa *lnh_double, int tag){
 
-    MPI_Send(lnh_double,1*LNH_SIZEH,MPI_DOUBLE,0,tag,MPI_COMM_WORLD);
+    MPI_Send(lnh_double,1*LNH_SIZEH,MPI_DOUBLE,0,tag,devinfo.mpi_comm);
 
 }
 void receive_lnh_subdouble_from_master(double_soa* lnh_double){
-    MPI_Recv(lnh_double,1*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,MPI_COMM_WORLD,
+    MPI_Recv(lnh_double,1*LNH_SIZEH,MPI_DOUBLE,0,devinfo.myrank,devinfo.mpi_comm,
             MPI_STATUS_IGNORE);
 }
 

--- a/src/Mpi/communications.h
+++ b/src/Mpi/communications.h
@@ -6,7 +6,7 @@
 #include "../OpenAcc/struct_c_def.h"
 
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 #include <mpi.h>
 // fermion border communications (only FERMION HALO thick)
 void communicate_fermion_borders(vec3_soa *lnh_fermion);

--- a/src/Mpi/dbgtools.h
+++ b/src/Mpi/dbgtools.h
@@ -209,17 +209,17 @@ void send_lnh_subfermion_to_rank(const global_vec3_soa * gl_soa_fermion, int tar
     }
 
     //sending the subfermion
-    MPI_Send(target_vec3_soa, 3*2*LNH_SIZEH , MPI_DOUBLE, target_rank, tag, MPI_COMM_WORLD);
+    MPI_Send(target_vec3_soa, 3*2*LNH_SIZEH , MPI_DOUBLE, target_rank, tag, devinfo.mpi_comm);
 
 }
 static inline void recv_lnh_subfermion_from_master(lnh_vec3_soa * lnh_fermion, int tag){
 
-    MPI_Recv(lnh_fermion, 3*2*LNH_SIZEH,MPI_DOUBLE,0,tag,MPI_COMM_WORLD,MPI_STATUS_IGNORE );
+    MPI_Recv(lnh_fermion, 3*2*LNH_SIZEH,MPI_DOUBLE,0,tag,devinfo.mpi_comm,MPI_STATUS_IGNORE );
     // ^^ CHECK
 }
 static inline void send_lnh_subfermion_to_master(lnh_vec3_soa * lnh_fermion, int tag){
 
-    MPI_Send(lnh_fermion, 3*2*LNH_SIZEH,MPI_DOUBLE,0,tag,MPI_COMM_WORLD );
+    MPI_Send(lnh_fermion, 3*2*LNH_SIZEH,MPI_DOUBLE,0,tag,devinfo.mpi_comm );
     // ^^ CHECK
 }
 void recv_loc_subfermion_from_rank(const global_vec3_soa * gl_soa_fermion, int rank, int tag){
@@ -232,7 +232,7 @@ void recv_loc_subfermion_from_rank(const global_vec3_soa * gl_soa_fermion, int r
     // building sublattice duplicate, target_conf
     lnh_vec3_soa* origin_vec3_soa = malloc(sizeof(lnh_vec3_soa)); 
     //receive the subfermion
-    MPI_Recv(origin_vec3_soa, 3*2*LNH_SIZEH , MPI_DOUBLE, rank, tag, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+    MPI_Recv(origin_vec3_soa, 3*2*LNH_SIZEH , MPI_DOUBLE, rank, tag, devinfo.mpi_comm, MPI_STATUS_IGNORE);
     // ^^ CHECK
 
     int or_loc_xh,or_loc_y,or_loc_z,or_loc_t; //target-lnh coordinates
@@ -621,9 +621,9 @@ void send_lnh_subconf_to_buffer(global_su3_soa *gl_soa_conf, lnh_su3_soa *lnh_co
 
     /*
     //sending the subconfiguration
-    MPI_Send(target_su3_soa, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE, rank, 0, MPI_COMM_WORLD);
+    MPI_Send(target_su3_soa, 2*4*(6*3)*LNH_SIZEH,MPI_DOUBLE, rank, 0, devinfo.mpi_comm);
     // In case we remove the third line, this is possibly the thing to do
-    //MPI_Send(target_su3_soa, 2*4*(6*2)*LNH_SIZEH,MPI_DOUBLE, rank, 0, MPI_COMM_WORLD);
+    //MPI_Send(target_su3_soa, 2*4*(6*2)*LNH_SIZEH,MPI_DOUBLE, rank, 0, devinfo.mpi_comm);
     //Or maybe do multiple sends in a more complicated way
     // ^^ CHECK
     */ // COMMENTED FOR TEST

--- a/src/Mpi/geometry_multidev.h
+++ b/src/Mpi/geometry_multidev.h
@@ -65,7 +65,7 @@
 #define MULTIDEVICE
 #endif
 
-#if defined(NREPLICAS) && !defined(MULTIDEVICE)
+#ifndef MULTIDEVICE
 #if NREPLICAS > 1
 #define MULTIDEVICE
 #endif

--- a/src/Mpi/geometry_multidev.h
+++ b/src/Mpi/geometry_multidev.h
@@ -65,6 +65,12 @@
 #define MULTIDEVICE
 #endif
 
+#ifdef NREPLICAS 
+#if NREPLICAS > 1
+#define MULTIDEVICE
+#endif
+#endif
+
 // Local aNd Halo lattice dimensions 
 // Hopefully automatically calculated by the compiler during optimization
 //AUTOMATIC DEFINITIONS OF LNH STUFF

--- a/src/Mpi/geometry_multidev.h
+++ b/src/Mpi/geometry_multidev.h
@@ -65,7 +65,7 @@
 #define MULTIDEVICE
 #endif
 
-#ifdef NREPLICAS 
+#if defined(NREPLICAS) && !defined(MULTIDEVICE)
 #if NREPLICAS > 1
 #define MULTIDEVICE
 #endif

--- a/src/Mpi/multidev.c
+++ b/src/Mpi/multidev.c
@@ -46,6 +46,12 @@ void pre_init_multidev1D(dev_info * mdi)
         printf("#MPI%02d:%02d: NRANKS_D3 = %d, nranks = %d\n",mdi->myrank, NRANKS_D3, mdi->replica_idx, mdi->nranks);
         exit(1);
     }
+
+    if(mdi->nranks_world != NREPLICAS*NRANKS_D3){
+        printf("#MPI%02d:%02d: NREPLICAS is different from nranks_world/nranks. Exiting now\n",mdi->replica_idx,mdi->myrank);
+        printf("#MPI%02d:%02d: NREPLICAS = %d, nranks_world/nranks = %d\n",NREPLICAS, mdi->nranks_world/mdi->nranks, mdi->replica_idx, mdi->nranks);
+        exit(1);
+    }
     
     if(verbosity_lv > 2){
         printf("MPI%02d:%02d - Called MPI_Init\n",mdi->replica_idx,mdi->myrank);

--- a/src/Mpi/multidev.c
+++ b/src/Mpi/multidev.c
@@ -30,9 +30,6 @@ void pre_init_multidev1D(dev_info * mdi)
       MPI_Comm_split(MPI_COMM_WORLD, mdi->replica_idx, mdi->myrank_world, &(mdi->mpi_comm));
       MPI_Comm_rank(mdi->mpi_comm,&(mdi->myrank));
       MPI_Comm_size(mdi->mpi_comm,&(mdi->nranks));
-
-      int color = (mdi->myrank==0)? 0: MPI_UNDEFINED;
-      MPI_Comm_split(MPI_COMM_WORLD, color, mdi->replica_idx, &(mdi->mpi_comm_salamino));
     }else{
       mdi->replica_idx=0;
       mdi->mpi_comm=MPI_COMM_WORLD;
@@ -69,8 +66,8 @@ void init_multidev1D(dev_info * mdi)
 
     sprintf(mdi->myrankstr,"MPI%02d",mdi->myrank);
 
-    MPI_PRINTF1("of \"%02d\" tasks running on host \"%s\", local rank: %d, rankL: %d, rankR: %d\n", mdi->processor_name, 
-    mdi->node_subrank, mdi->myrank_L, mdi->myrank_R); //SALAMINO
+    MPI_PRINTF1("of \"%02d\" tasks running on host \"%s\", replica index: %d, local rank: %d, rankL: %d, rankR: %d\n", mdi->nranks_world, mdi->processor_name, 
+    mdi->replica_idx, mdi->node_subrank, mdi->myrank_L, mdi->myrank_R); //SALAMINO
 
     mdi->myrank4int = xyzt_rank(mdi->myrank); // ALL RANKS
 
@@ -108,21 +105,12 @@ void init_multidev1D(dev_info * mdi)
                 mdi->origin_0123[2], mdi->origin_0123[3]);
    
     }
-
-
 }
-
-
-
-
-
 
 void shutdown_multidev()
 {
-
     MPI_PRINTF0("Finalizing...\n" );
     MPI_Finalize();     
-
 }
 
 

--- a/src/Mpi/multidev.c
+++ b/src/Mpi/multidev.c
@@ -25,15 +25,16 @@ void pre_init_multidev1D(dev_info * mdi)
     MPI_Get_processor_name(mdi->processor_name,&(mdi->namelen));
 
     // associate to specific replica communication group
-    int replica_num = mdi->myrank_world/NRANKS_D3;
-    if(replica_num>1){
-      MPI_Comm_split(MPI_COMM_WORLD, replica_num, &(mdi->mpi_comm));
-      MPI_Comm_rank(mdi->mpi_comm,&(mpi->myrank));
-      MPI_Comm_size(mdi->mpi_comm,&(mpi->nranks));
+    if(mdi->nranks_world/NRANKS_D3>1){
+      mdi->replica_idx = mdi->myrank_world/NRANKS_D3;
+      MPI_Comm_split(MPI_COMM_WORLD, mdi->replica_idx, mdi->myrank_world, &(mdi->mpi_comm));
+      MPI_Comm_rank(mdi->mpi_comm,&(mdi->myrank));
+      MPI_Comm_size(mdi->mpi_comm,&(mdi->nranks));
     }else{
+      mdi->replica_idx=0;
       mdi->mpi_comm=MPI_COMM_WORLD;
-      mpi->myrank=mdi->myrank_world;
-      mpi->nranks=mdi->nranks_world;
+      mdi->myrank=mdi->myrank_world;
+      mdi->nranks=mdi->nranks_world;
     }
 
 

--- a/src/Mpi/multidev.c
+++ b/src/Mpi/multidev.c
@@ -30,6 +30,9 @@ void pre_init_multidev1D(dev_info * mdi)
       MPI_Comm_split(MPI_COMM_WORLD, mdi->replica_idx, mdi->myrank_world, &(mdi->mpi_comm));
       MPI_Comm_rank(mdi->mpi_comm,&(mdi->myrank));
       MPI_Comm_size(mdi->mpi_comm,&(mdi->nranks));
+
+      int color = (mdi->myrank==0)? 0: MPI_UNDEFINED;
+      MPI_Comm_split(MPI_COMM_WORLD, color, mdi->replica_idx, &(mdi->mpi_comm_salamino));
     }else{
       mdi->replica_idx=0;
       mdi->mpi_comm=MPI_COMM_WORLD;

--- a/src/Mpi/multidev.c
+++ b/src/Mpi/multidev.c
@@ -39,13 +39,13 @@ void pre_init_multidev1D(dev_info * mdi)
 
 
     if(mdi->nranks != NRANKS_D3){
-        printf("#MPI%02d: NRANKS_D3 is different from nranks: no salamino? Exiting now\n",mdi->myrank);
-        printf("#MPI%02d: NRANKS_D3 = %d, nranks = %d\n",mdi->myrank, NRANKS_D3, mdi->nranks);
+        printf("#MPI%02d:%02d: NRANKS_D3 is different from nranks: no salamino? Exiting now\n",mdi->replica_idx,mdi->myrank);
+        printf("#MPI%02d:%02d: NRANKS_D3 = %d, nranks = %d\n",mdi->myrank, NRANKS_D3, mdi->replica_idx, mdi->nranks);
         exit(1);
     }
     
     if(verbosity_lv > 2){
-        printf("MPI%02d - Called MPI_Init\n",mdi->myrank);
+        printf("MPI%02d:%02d - Called MPI_Init\n",mdi->replica_idx,mdi->myrank);
     }
 
 

--- a/src/Mpi/multidev.c
+++ b/src/Mpi/multidev.c
@@ -42,19 +42,19 @@ void pre_init_multidev1D(dev_info * mdi)
 
 
     if(mdi->nranks != NRANKS_D3){
-        printf("#MPI%02d:%02d: NRANKS_D3 is different from nranks: no salamino? Exiting now\n",mdi->replica_idx,mdi->myrank);
-        printf("#MPI%02d:%02d: NRANKS_D3 = %d, nranks = %d\n",mdi->myrank, NRANKS_D3, mdi->replica_idx, mdi->nranks);
+        MPI_PRINTF0("NRANKS_D3 is different from nranks: no salamino? Exiting now\n");
+        MPI_PRINTF1("NRANKS_D3 = %d, nranks = %d\n",mdi->myrank, NRANKS_D3);
         exit(1);
     }
 
     if(mdi->nranks_world != NREPLICAS*NRANKS_D3){
-        printf("#MPI%02d:%02d: NREPLICAS is different from nranks_world/nranks. Exiting now\n",mdi->replica_idx,mdi->myrank);
-        printf("#MPI%02d:%02d: NREPLICAS = %d, nranks_world/nranks = %d\n",NREPLICAS, mdi->nranks_world/mdi->nranks, mdi->replica_idx, mdi->nranks);
+        MPI_PRINTF0("NREPLICAS is different from nranks_world/nranks. Exiting now\n");
+        MPI_PRINTF1("NREPLICAS = %d, nranks_world/nranks = %d\n",NREPLICAS, mdi->nranks_world/mdi->nranks);
         exit(1);
     }
     
     if(verbosity_lv > 2){
-        printf("MPI%02d:%02d - Called MPI_Init\n",mdi->replica_idx,mdi->myrank);
+        MPI_PRINTF0("- Called MPI_Init\n");
     }
 
 
@@ -69,8 +69,7 @@ void init_multidev1D(dev_info * mdi)
 
     sprintf(mdi->myrankstr,"MPI%02d",mdi->myrank);
 
-    printf("#MPI%02d: of \"%02d\" tasks running on host \"%s\", local rank: %d, rankL: %d, rankR: %d\n",
-    mdi->myrank, mdi->nranks, mdi->processor_name, 
+    MPI_PRINTF1("of \"%02d\" tasks running on host \"%s\", local rank: %d, rankL: %d, rankR: %d\n", mdi->processor_name, 
     mdi->node_subrank, mdi->myrank_L, mdi->myrank_R); //SALAMINO
 
     mdi->myrank4int = xyzt_rank(mdi->myrank); // ALL RANKS
@@ -103,8 +102,8 @@ void init_multidev1D(dev_info * mdi)
     mdi->origin_0123[2]     = mdi->gl_loc_origin4int.d2;
     mdi->origin_0123[3]     = mdi->gl_loc_origin4int.d3;
     if(verbosity_lv > 2){
-        printf("MPI%02d - Finished init_multidev1D\n", mdi->myrank);   
-        printf("MPI%02d - Origin(%d,%d,%d,%d)",mdi->myrank,
+        MPI_PRINTF0("- Finished init_multidev1D\n");   
+        MPI_PRINTF1("- Origin(%d,%d,%d,%d)",
                 mdi->origin_0123[0],mdi->origin_0123[1],
                 mdi->origin_0123[2], mdi->origin_0123[3]);
    
@@ -121,7 +120,7 @@ void init_multidev1D(dev_info * mdi)
 void shutdown_multidev()
 {
 
-    printf("MPI%02d: Finalizing...\n",devinfo.myrank );
+    MPI_PRINTF0("Finalizing...\n" );
     MPI_Finalize();     
 
 }

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -43,6 +43,11 @@ typedef struct dev_info_t{
 
 extern dev_info devinfo;
 
+//TODO: generalize and write like this in all files
+//#define MPI_PRINTF(fmt) printf("MPI%02d:%02d - " (fmt) ,devinfo.replica_idx, devinfo.myrank); 
+#define MPI_PRINTF0(fmt) printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank);  
+#define MPI_PRINTF1(fmt,...) printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank, __VA_ARGS__);  
+
 
 #ifdef MULTIDEVICE
 

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -14,7 +14,7 @@ typedef struct dev_info_t{
     int single_dev_choice; // from input file
     int myrank_world, nranks_world;
     int myrank, nranks;
-    int replica_idx;
+    int replica_idx, num_replicas;
     char myrankstr[50];
     int nranks_read;
 
@@ -43,10 +43,21 @@ typedef struct dev_info_t{
 
 extern dev_info devinfo;
 
-//TODO: generalize and write like this in all files
-//#define MPI_PRINTF(fmt) printf("MPI%02d:%02d - " (fmt) ,devinfo.replica_idx, devinfo.myrank); 
-#define MPI_PRINTF0(fmt) printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank);  
-#define MPI_PRINTF1(fmt,...) printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank, __VA_ARGS__);  
+#define MPI_PRINTF0(fmt) { \
+  if(devinfo.num_replicas>1){ \
+    printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank); \
+  }else{ \
+    printf("MPI%02d - " fmt ,devinfo.myrank); \
+  }}
+#define MPI_PRINTF1(fmt,...) { \
+  if(devinfo.num_replicas>1){ \
+    printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank, __VA_ARGS__); \
+  }else{ \
+    printf("MPI%02d - " fmt ,devinfo.myrank, __VA_ARGS__); \
+  }}
+
+//TODO: this doesn't work for some reason (it works with gcc), find out why
+// #define MPI_PRINTF(fmt,...) printf("MPI%02d:%02d - " fmt ,devinfo.replica_idx, devinfo.myrank, ##__VA_ARGS__);  
 
 
 #ifdef MULTIDEVICE

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -20,7 +20,6 @@ typedef struct dev_info_t{
 
 #ifdef MULTIDEVICE
     MPI_Comm mpi_comm;
-    MPI_Comm mpi_comm_salamino; //TODO: test if really necessary
     int async_comm_fermion;
     int async_comm_gauge;
 

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -16,6 +16,7 @@ typedef struct dev_info_t{
     int myrank, nranks;
     int replica_idx;
     MPI_Comm mpi_comm;
+    MPI_Comm mpi_comm_salamino; //TODO: test if really necessary
     char myrankstr[50];
     int nranks_read;
 

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -15,12 +15,12 @@ typedef struct dev_info_t{
     int myrank_world, nranks_world;
     int myrank, nranks;
     int replica_idx;
-    MPI_Comm mpi_comm;
-    MPI_Comm mpi_comm_salamino; //TODO: test if really necessary
     char myrankstr[50];
     int nranks_read;
 
 #ifdef MULTIDEVICE
+    MPI_Comm mpi_comm;
+    MPI_Comm mpi_comm_salamino; //TODO: test if really necessary
     int async_comm_fermion;
     int async_comm_gauge;
 

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -14,6 +14,7 @@ typedef struct dev_info_t{
     int single_dev_choice; // from input file
     int myrank_world, nranks_world;
     int myrank, nranks;
+    int replica_idx;
     MPI_Comm mpi_comm;
     char myrankstr[50];
     int nranks_read;

--- a/src/Mpi/multidev.h
+++ b/src/Mpi/multidev.h
@@ -12,7 +12,9 @@ typedef struct dev_info_t{
     // FROM MPI INIT AND SIMILAR
     
     int single_dev_choice; // from input file
+    int myrank_world, nranks_world;
     int myrank, nranks;
+    MPI_Comm mpi_comm;
     char myrankstr[50];
     int nranks_read;
 

--- a/src/OpenAcc/HPT_utilities.c
+++ b/src/OpenAcc/HPT_utilities.c
@@ -742,7 +742,7 @@ void manage_replica_swaps(
     MPI_Bcast((void*)&swap_order,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
 
     int accepted=0;
-    int i_counter, j_counter; // indexes, not labels
+    int i_counter, j_counter; // labels, not indexes
     int rep_lab1,rep_lab2;
     for(i_counter=0;i_counter<replicas_number-1;i_counter++){
       // manages each pairs serially in a chained fashion
@@ -755,12 +755,12 @@ void manage_replica_swaps(
 
       if(swap_order<=0.5){ 
 //        MPI_PRINTF0("Swap order: 0->N_r-1\n"); //
-        rep_lab1=hpt_params->label[i_counter];
-        rep_lab2=hpt_params->label[i_counter+1];
+        rep_lab1=i_counter;
+        rep_lab2=i_counter+1;
       }else{
 //        MPI_PRINTF0("Swap order: N_r-1->0\n");
-        rep_lab1=hpt_params->label[replicas_number-i_counter-1];
-        rep_lab2=hpt_params->label[replicas_number-i_counter-2];
+        rep_lab1=replicas_number-i_counter-1;
+        rep_lab2=replicas_number-i_counter-2;
       }
 
 //        if(verbosity_lv>4) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
@@ -806,10 +806,10 @@ void manage_replica_swaps(
 
       if (0==devinfo.myrank_world){
         // compute acceptance:
-        double Delta_S_SWAP =  S_arr_next[rep_lab1]
+        double Delta_S_SWAP =  -(S_arr_next[rep_lab1]
                               +S_arr_next[rep_lab2]
                               -S_arr_prev[rep_lab1]
-                              -S_arr_prev[rep_lab2];
+                              -S_arr_prev[rep_lab2]);
         accepted=metro_SWAP_worldmaster(Delta_S_SWAP);
         printf("DELTA_S_SWAP(lab1=%d,lab2=%d):%.15lg\n", rep_lab1, rep_lab2, Delta_S_SWAP);
         //if(verbosity_lv>8) printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n",

--- a/src/OpenAcc/HPT_utilities.c
+++ b/src/OpenAcc/HPT_utilities.c
@@ -27,7 +27,7 @@
 
 #include <time.h>
 
-void init_k(su3_soa * conf, double c_r, int def_axis, int * def_vec, defect_info * def,int defect_info_config){
+void init_k(su3_soa * conf, double c_r, int def_axis, int * def_vec, defect_info * def, int defect_info_config){
   
   int mu, i, parity, condition, condition_2=1, condition_3=1;
   int def_vec_4d[4] = {0};
@@ -37,9 +37,9 @@ void init_k(su3_soa * conf, double c_r, int def_axis, int * def_vec, defect_info
   int def_axis_mapped=map[def_axis];
   if(defect_info_config==0){ def->def_axis_mapped=def_axis_mapped; }
 
-  // initializzation
+  // initialization
   int nd[4]={nd0-1,nd1-1,nd2-1,nd3-1};
-  if(defect_info_config==0){   
+  if(defect_info_config==0){
     for(int nu=0; nu<4;nu++){
       for (i=0; i<3; i++){
 				def->defect_swap_max[nu][i]=0;
@@ -66,7 +66,7 @@ void init_k(su3_soa * conf, double c_r, int def_axis, int * def_vec, defect_info
   // def_vec_4d stores the defect extent along PHYSICAL coordinates, def_axis the boundary on which defect is put in PHYSICAL coords
   // def_vec represents the defect length along the PHYSICAL directions orthogonal to def_axis following the x-y-z-t order.
   // if def_axis=0 (x) => def_vec[0-1-2] = length_def_y-z-t,  if def_axis=1 (y) => def_vec[0-1-2] = length_def_x-z-t and so on...
-  // WARING: This is independent of the physical-logical axis map of the lattice specified in the input file.
+  // WARNING: This is independent of the physical-logical axis map of the lattice specified in the input file.
   // thus, if in input defect_boundary = 0(1-2-3), def_axis will be put on the x(y-z-t) boundary REGARDLESS of the specified axis mapping
 
   def_vec_4d[def_axis]=1; // along def boundary, def extent is 1
@@ -324,34 +324,34 @@ void printing_k_mu(su3_soa * conf){
   }
 }
 
-// swap conf pointers for a given couple
-void replicas_swap(su3_soa * conf1, su3_soa * conf2, int lab1, int lab2, rep_info * hpt_params){
-  vec3_soa  aux;
-  int aux_label;
-  int mu=0;
-
-	// swap labels
-  aux_label=hpt_params->label[lab1];
-  hpt_params->label[lab1] = hpt_params->label[lab2];
-  hpt_params->label[lab2] = aux_label;
-
-  for(mu=0;mu<8;mu++){
-    // swap r0
-    aux=conf1[mu].r0;
-    conf1[mu].r0=conf2[mu].r0;
-    conf2[mu].r0=aux;
-        
-    // swap r1
-    aux=conf1[mu].r1;
-    conf1[mu].r1=conf2[mu].r1;
-    conf2[mu].r1=aux;
-        
-    // swap r2
-    aux=conf1[mu].r2;
-    conf1[mu].r2=conf2[mu].r2;
-    conf2[mu].r2=aux;
-  }
-}
+//// swap conf pointers for a given couple
+//void replicas_swap(su3_soa * conf1, su3_soa * conf2, int lab1, int lab2, rep_info * hpt_params){
+//  vec3_soa  aux;
+//  int aux_label;
+//  int mu=0;
+//
+//	// swap labels
+//  aux_label=hpt_params->label[lab1];
+//  hpt_params->label[lab1] = hpt_params->label[lab2];
+//  hpt_params->label[lab2] = aux_label;
+//
+//  for(mu=0;mu<8;mu++){
+//    // swap r0
+//    aux=conf1[mu].r0;
+//    conf1[mu].r0=conf2[mu].r0;
+//    conf2[mu].r0=aux;
+//        
+//    // swap r1
+//    aux=conf1[mu].r1;
+//    conf1[mu].r1=conf2[mu].r1;
+//    conf2[mu].r1=aux;
+//        
+//    // swap r2
+//    aux=conf1[mu].r2;
+//    conf1[mu].r2=conf2[mu].r2;
+//    conf2[mu].r2=aux;
+//  }
+//}
 
 // print conf labels
 void label_print(rep_info * hpt_params, FILE *file, int step_number){
@@ -364,11 +364,41 @@ void label_print(rep_info * hpt_params, FILE *file, int step_number){
   fprintf(file,"\n");
 }
 
-double calc_Delta_S_soloopenacc_SWAP(
-																		 __restrict  su3_soa * const tconf_acc,
-																		 __restrict  su3_soa * const tconf_acc2,
-																		 __restrict su3_soa * const local_plaqs,
-																		 dcomplex_soa * const tr_local_plaqs,defect_info * def)
+//double calc_Delta_S_soloopenacc_SWAP(
+//																		 __restrict  su3_soa * const tconf_acc,
+//																		 __restrict  su3_soa * const tconf_acc2,
+//																		 __restrict su3_soa * const local_plaqs,
+//																		 dcomplex_soa * const tr_local_plaqs,defect_info * def)
+//{
+//  double result=0.0;
+//  double total_result=0.0;
+//  int mu,nu;
+//  mu=def->def_axis_mapped;
+//  int counter=0;
+//
+//  for(counter=0;counter<3;counter++){
+//    nu=def->def_mapped_perp_dir[counter];
+//		
+//		// result = C_0 * delta_S_plaq_1x1
+//    result += C_ZERO * calc_Delta_S_Wilson_SWAP(tconf_acc,tconf_acc2,local_plaqs,tr_local_plaqs,mu,nu,def);
+//#ifdef GAUGE_ACT_TLSM
+//		// result + C_1 * ( delta_S_rect_1x2 + delta_S_rect_2x1 )
+//    result += C_ONE * calc_Delta_S_Symanzik_SWAP(tconf_acc,tconf_acc2,local_plaqs,tr_local_plaqs,mu,nu,def);
+//#endif
+//  }
+//#ifdef MULTIDEVICE
+//  MPI_Allreduce((void*)&result,(void*)&total_result,
+//								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
+//#else
+//  total_result = result;
+//#endif
+//  return total_result;
+//}
+
+
+double calc_S_soloopenacc_defect(__restrict  su3_soa * const tconf_acc,
+																 __restrict su3_soa * const local_plaqs,
+																 dcomplex_soa * const tr_local_plaqs,defect_info * def)
 {
   double result=0.0;
   double total_result=0.0;
@@ -378,12 +408,13 @@ double calc_Delta_S_soloopenacc_SWAP(
 
   for(counter=0;counter<3;counter++){
     nu=def->def_mapped_perp_dir[counter];
+
 		
 		// result = C_0 * delta_S_plaq_1x1
-    result += C_ZERO * calc_Delta_S_Wilson_SWAP(tconf_acc,tconf_acc2,local_plaqs,tr_local_plaqs,mu,nu,def);
+    result += C_ZERO * calc_S_Wilson_defect(tconf_acc,local_plaqs,tr_local_plaqs,mu,nu,def);
 #ifdef GAUGE_ACT_TLSM
 		// result + C_1 * ( delta_S_rect_1x2 + delta_S_rect_2x1 )
-    result += C_ONE * calc_Delta_S_Symanzik_SWAP(tconf_acc,tconf_acc2,local_plaqs,tr_local_plaqs,mu,nu,def);
+    result += C_ONE * calc_S_Symanzik_defect(tconf_acc,local_plaqs,tr_local_plaqs,mu,nu,def);
 #endif
   }
 #ifdef MULTIDEVICE
@@ -395,12 +426,174 @@ double calc_Delta_S_soloopenacc_SWAP(
   return total_result;
 }
 
+void compute_S_of_replicas(
+                        __restrict su3_soa * const tconf_acc, 
+                        __restrict su3_soa * const local_plaq, 
+                        dcomplex_soa * const tr_local_plaqs,
+                        defect_info * def,
+                        double * S_arr){
+  // compute and write on 
+//  if(devinfo.myrank==0){
+//    // like this:
+////#ifdef MULTIDEVICE
+////  MPI_Allreduce((void*)&result,(void*)&total_result,
+////								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
+////#else
+//    S_arr_prev[devinfo.replica_idx]=devinfo.replica_idx;
+//    S_arr_next[devinfo.replica_idx]=devinfo.replica_idx;
+//  }
+
+  // alternative version:
+  // reduce on all world ranks
+  //TODO: replace with true computations
+  double S_val[NREPLICAS];
+  for(int r=0; r<NREPLICAS; ++r){
+    S_val[r]=0.0;
+  }
+
+
+  //double S_prev_loc=(double)(devinfo.nranks*devinfo.replica_idx+devinfo.myrank); 
+  double S_loc=calc_S_soloopenacc_defect(tconf_acc,local_plaq, tr_local_plaqs,def);
+
+
+  // master decides swap attempts and send command of actions recomputation
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+
+//XXX debug:  double S_loc=(double)(devinfo.nranks_world*devinfo.replica_idx+devinfo.myrank_world);
+
+//  MPI_PRINTF1("S_prev_loc:%lf\n",S_prev_loc);
+//  MPI_PRINTF1("S_next_loc:%lf\n",S_next_loc);
+  int rep_idx=devinfo.replica_idx;
+
+  MPI_Reduce((void*)&S_loc,(void*)&S_val[rep_idx], 1,MPI_DOUBLE, MPI_SUM, 0, devinfo.mpi_comm);
+//  MPI_Reduce((void*)&S_next_loc,(void*)&S_next[rep_idx], 1,MPI_DOUBLE, MPI_SUM, 0, devinfo.mpi_comm);
+//  MPI_PRINTF1("S_prev:%lf\n",S_prev);
+//  MPI_PRINTF1("S_next:%lf\n",S_next);
+  
+  for(int r=0; r<NREPLICAS; ++r){
+    MPI_Reduce(&S_val[r], &S_arr[r], 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+//    MPI_Reduce(&S_next[r], &S_arr_next[r], 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  }
+}
+
+//// compute delta_S_plaq = (beta/3) * sum delta_K_1x1 delta_Tr(plaq_1x1)
+//double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
+//                                __restrict const su3_soa * const w,
+//                                __restrict su3_soa * const loc_plaq,
+//                                dcomplex_soa * const tr_local_plaqs,
+//                                const int mu, const int nu, defect_info * def)
+//{
+//  double K_mu_nu;
+//  double K_mu_nu2;
+//  int d0,d1,d2,d3;
+//  int i;
+//
+//  int D0_min,D1_min,D2_min,D3_min;
+//  int D0_max,D1_max,D2_max,D3_max;
+//
+//  D0_min=def->defect_swap_min[nu][0];
+//  D1_min=def->defect_swap_min[nu][1];
+//  D2_min=def->defect_swap_min[nu][2];
+//  D3_min=def->defect_swap_min[nu][3];
+//
+//  D0_max=def->defect_swap_max[nu][0];
+//  D1_max=def->defect_swap_max[nu][1];
+//  D2_max=def->defect_swap_max[nu][2];
+//  D3_max=def->defect_swap_max[nu][3];
+//
+//  for(i=0; i<sizeh;i++){
+//    tr_local_plaqs[0].c[i]=0;
+//    tr_local_plaqs[1].c[i]=0;
+//  }
+//	#pragma acc update device(tr_local_plaqs[0:2])
+//
+//	#pragma acc kernels present(u) present(w) present(loc_plaq) present(tr_local_plaqs)
+//	#pragma acc loop independent gang(STAPGANG3)
+//  for(d3=D3_min; d3<D3_max; d3++) {
+//		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
+//    for(d2=D2_min; d2<D2_max; d2++) {
+//      for(d1=D1_min; d1<D1_max; d1++) {
+//				for(d0=D0_min; d0<D0_max; d0++) {
+//                
+//					int idxh,idxpmu,idxpnu;
+//					int parity;
+//					int dir_muA,dir_nuB;
+//					int dir_muC,dir_nuD;
+//                
+//					idxh = snum_acc(d0,d1,d2,d3); // site r
+//					parity = (d0+d1+d2+d3) % 2;
+//
+//					// impose periodic boundary conditions
+//					if(d1==-1){parity = (d0+d2+d3) % 2; idxh=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];parity=!parity;}
+//					if(d2==-1){parity = (d0+d1+d3) % 2; idxh=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];parity=!parity;}
+//					if(d0==-1){parity = (d3+d1+d2) % 2; idxh=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];parity=!parity;}
+//					if(d3==-1){parity = (d0+d1+d2) % 2; idxh=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];parity=!parity;}
+//                
+//					dir_muA = 2*mu +  parity;
+//					dir_muC = 2*mu + !parity;
+//					idxpmu = nnp_openacc[idxh][mu][parity]; // r+mu
+//                
+//					dir_nuB = 2*nu + !parity;
+//					dir_nuD = 2*nu +  parity;
+//					idxpnu = nnp_openacc[idxh][nu][parity]; // r+nu
+//                
+//					//       r+nu (C)  r+mu+nu
+//					//          +<---+
+//					// nu       |    ^
+//					// ^    (D) V    | (B)
+//					// |        +--->+
+//					// |       r  (A)  r+mu
+//					// +---> mu
+//                
+//					// plaquette u
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&u[dir_muA],idxh,&u[dir_nuB],idxpmu,&loc_plaq[parity],idxh);  // loc_plaq = A * B
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&u[dir_muC],idxpnu);              // loc_plaq = loc_plaq * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&u[dir_nuD],idxh);                // loc_plaq = loc_plaq * D
+//                
+//					d_complex ciao = matrix_trace_absent_stag_phase(&loc_plaq[parity],idxh); // tr(plaq_u)
+//					tr_local_plaqs[parity].c[idxh] = creal(ciao)+cimag(ciao)*I;
+//                
+//					// K_{mu nu} u
+//					K_mu_nu=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_muC].K.d[idxpnu])*(u[dir_nuD].K.d[idxh]);
+//                
+//					// plaquette w
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_plaq[parity],idxh);  // loc_plaq = A * B
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&w[dir_muC],idxpnu);              // loc_plaq = loc_plaq * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&w[dir_nuD],idxh);                // loc_plaq = loc_plaq * D
+//                
+//					// K_{mu nu} w
+//					K_mu_nu2=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_muC].K.d[idxpnu])*(w[dir_nuD].K.d[idxh]);
+//                
+//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_plaq[parity],idxh);
+//                
+//					tr_local_plaqs[parity].c[idxh] = tr_local_plaqs[parity].c[idxh]-creal(ciao2)-cimag(ciao2)*I; // tr(plaq)_u - tr(plaq)_w 
+//					tr_local_plaqs[parity].c[idxh] = (K_mu_nu-K_mu_nu2)*tr_local_plaqs[parity].c[idxh]; // Delta_K * Delta_Tr_plaq = - Delta_S
+//				} // d0  
+//      } // d1
+//    } // d2
+//  } // d3
+//
+//  double res_R_p = 0.0;
+//  double res_I_p = 0.0;
+//  double resR = 0.0;
+//  int t;
+//
+//	#pragma acc kernels present(tr_local_plaqs)
+//	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
+//  for(t=0; t<sizeh; t++) {
+//    res_R_p += creal(tr_local_plaqs[0].c[t]); // even sites plaquettes
+//    res_R_p += creal(tr_local_plaqs[1].c[t]); // odd sites plaquettes
+//  }
+//  res_R_p *= BETA_BY_THREE; // Delta_S = (beta/3) Sum Delta_K * Delta_Tr_plaq
+//  return res_R_p;
+//}
+
 // compute delta_S_plaq = (beta/3) * sum delta_K_1x1 delta_Tr(plaq_1x1)
-double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
-                                __restrict const su3_soa * const w,
-                                __restrict su3_soa * const loc_plaq,
-                                dcomplex_soa * const tr_local_plaqs,
-                                const int mu, const int nu, defect_info * def)
+double calc_S_Wilson_defect(__restrict const su3_soa * const u,
+                              __restrict su3_soa * const loc_plaq,
+                              dcomplex_soa * const tr_local_plaqs,
+                              const int mu, const int nu, defect_info * def)
 {
   double K_mu_nu;
   double K_mu_nu2;
@@ -409,6 +602,7 @@ double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
 
   int D0_min,D1_min,D2_min,D3_min;
   int D0_max,D1_max,D2_max,D3_max;
+
 
   D0_min=def->defect_swap_min[nu][0];
   D1_min=def->defect_swap_min[nu][1];
@@ -426,7 +620,7 @@ double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
   }
 	#pragma acc update device(tr_local_plaqs[0:2])
 
-	#pragma acc kernels present(u) present(w) present(loc_plaq) present(tr_local_plaqs)
+	#pragma acc kernels present(u) present(loc_plaq) present(tr_local_plaqs)
 	#pragma acc loop independent gang(STAPGANG3)
   for(d3=D3_min; d3<D3_max; d3++) {
 		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
@@ -474,19 +668,8 @@ double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
                 
 					// K_{mu nu} u
 					K_mu_nu=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_muC].K.d[idxpnu])*(u[dir_nuD].K.d[idxh]);
-                
-					// plaquette w
-					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_plaq[parity],idxh);  // loc_plaq = A * B
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&w[dir_muC],idxpnu);              // loc_plaq = loc_plaq * C
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&w[dir_nuD],idxh);                // loc_plaq = loc_plaq * D
-                
-					// K_{mu nu} w
-					K_mu_nu2=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_muC].K.d[idxpnu])*(w[dir_nuD].K.d[idxh]);
-                
-					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_plaq[parity],idxh);
-                
-					tr_local_plaqs[parity].c[idxh] = tr_local_plaqs[parity].c[idxh]-creal(ciao2)-cimag(ciao2)*I; // tr(plaq)_u - tr(plaq)_w 
-					tr_local_plaqs[parity].c[idxh] = (K_mu_nu-K_mu_nu2)*tr_local_plaqs[parity].c[idxh]; // Delta_K * Delta_Tr_plaq = - Delta_S
+
+            tr_local_plaqs[parity].c[idxh] = K_mu_nu*tr_local_plaqs[parity].c[idxh];
 				} // d0  
       } // d1
     } // d2
@@ -507,10 +690,232 @@ double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
   return res_R_p;
 }
 
+//// compute Delta_S = (beta/3) Sum [ Delta_K_rect_1x2 * Delta_Tr(rect)_1x2 + 1x2 ---> 2x1 ]
+//#ifdef GAUGE_ACT_TLSM
+//double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
+//                                  __restrict const su3_soa * const w,
+//                                  __restrict su3_soa * const loc_rects,
+//                                  dcomplex_soa * const tr_local_rects,
+//                                  const int mu, const int nu, defect_info * def)
+//{
+//  double K_mu_nu;
+//  double K_mu_nu2;
+//  int d0, d1, d2, d3;
+//  int D0_min,D1_min,D2_min,D3_min;
+//  int D0_max,D1_max,D2_max,D3_max;
+//
+//  // min and max init
+//  D0_max=def->defect_swap_max_TLSM[1][nu][0];
+//  D1_max=def->defect_swap_max_TLSM[1][nu][1];
+//  D2_max=def->defect_swap_max_TLSM[1][nu][2];
+//  D3_max=def->defect_swap_max_TLSM[1][nu][3];
+//
+//  D0_min=def->defect_swap_min_TLSM[1][nu][0];
+//  D1_min=def->defect_swap_min_TLSM[1][nu][1];
+//  D2_min=def->defect_swap_min_TLSM[1][nu][2];
+//  D3_min=def->defect_swap_min_TLSM[1][nu][3];
+//
+//  int idxh,idxpmu,idxpnu;
+//  int parity;
+//  int dir_muA,dir_nuB;
+//  int dir_muC,dir_nuD;
+//
+//  int dir_muB,dir_muD,dir_nuC;
+//  int dir_muE,dir_nuF,dir_nuE;
+//  int idxpmupmu,idxpmupnu; // 2x1
+//  int idxpnupnu; // 1x2
+//
+//  int is;
+//  for(is=0; is<sizeh;is++){
+//    tr_local_rects[0].c[is]=0;
+//    tr_local_rects[1].c[is]=0;
+//  }
+//	#pragma acc update device(tr_local_rects[0:2])
+//
+//  // 2x1
+//	#pragma acc kernels present(u) present(w) present(loc_rects) present(tr_local_rects)
+//	#pragma acc loop independent gang(STAPGANG3)
+//  for(d3=D3_min; d3< D3_max; d3++) {
+//		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
+//    for(d2=D2_min; d2< D2_max; d2++) {
+//      for(d1=D1_min; d1< D1_max; d1++) {
+//				for(d0=D0_min; d0< D0_max; d0++) {
+//
+//					idxh = snum_acc(d0,d1,d2,d3);
+//					parity = (d0+d1+d2+d3) % 2; 
+//
+//					if(d1==-1){parity = (d0+d2+d3) % 2; idxh=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];parity=!parity;}
+//					if(d2==-1){parity = (d0+d1+d3) % 2; idxh=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];parity=!parity;}
+//					if(d0==-1){parity = (d3+d1+d2) % 2; idxh=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];parity=!parity;}
+//					if(d3==-1){parity = (d0+d1+d2) % 2; idxh=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];parity=!parity;}
+//
+//					dir_muA = 2*mu +  parity;
+//					dir_muB = 2*mu + !parity;
+//					dir_nuC = 2*nu +  parity;
+//					dir_muD = 2*mu +  parity;
+//					dir_muE = 2*mu + !parity;
+//					dir_nuF = 2*nu +  parity;
+//					idxpmu = nnp_openacc[idxh][mu][parity]; // r+mu
+//					idxpmupmu = nnp_openacc[idxpmu][mu][!parity]; // r+2mu
+//					idxpmupnu = nnp_openacc[idxpmu][nu][!parity];// r+mu+nu
+//					idxpnu = nnp_openacc[idxh][nu][parity]; // r+nu
+//
+//					//       r+nu r+mu+nu r+2mu+nu
+//					//          +<---+<---+
+//					// nu       | (E) (D) ^
+//					// ^    (F) V (A) (B) |  (C)
+//					// |        +--->+--->+
+//					// |       r   r+mu r+2mu
+//					// +---> mu
+//
+//					// rect 2x1 u
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&u[dir_muA],idxh,&u[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
+//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_muE],idxpnu);               // loc_rect = loc_rect * E
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuF],idxh);                 // loc_rect = loc_rect * F
+//					d_complex ciao = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
+//
+//					// K_mu_nu_RECT 2x1 u
+//					double K_mu_nu_RECT;
+//					K_mu_nu_RECT=(u[dir_muA].K.d[idxh])*(u[dir_muB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupmu])*(u[dir_muD].K.d[idxpmupnu])*(u[dir_muE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
+//
+//					// rect 2x1 w
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
+//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muE],idxpnu);               // loc_rect = loc_rect * E
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
+//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
+//
+//					// K_mu_nu_RECT 2x1 w 
+//					double K_mu_nu_RECT2;
+//					K_mu_nu_RECT2=(w[dir_muA].K.d[idxh])*(w[dir_muB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupmu])*(w[dir_muD].K.d[idxpmupnu])*(w[dir_muE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
+//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT-K_mu_nu_RECT2)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
+//				} //d0
+//      } // d1
+//    } // d2
+//  } // d3
+//
+//  double res_R_p = 0.0;
+//  double res_I_p = 0.0;
+//  double resR = 0.0;
+//  int t;
+//
+//	#pragma acc kernels present(tr_local_rects)
+//	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
+//  for(t=0; t  < sizeh; t++) {
+//    res_R_p += creal(tr_local_rects[0].c[t]); // even sites rectangles
+//    res_R_p += creal(tr_local_rects[1].c[t]); // odd sites reactangles
+//  }
+//
+//  // 1x2
+//  // min and max init
+//  int idxh1;
+//  D0_max=def->defect_swap_max_TLSM[0][nu][0];
+//  D1_max=def->defect_swap_max_TLSM[0][nu][1];
+//  D2_max=def->defect_swap_max_TLSM[0][nu][2];
+//  D3_max=def->defect_swap_max_TLSM[0][nu][3];
+//
+//  D0_min=def->defect_swap_min_TLSM[0][nu][0];
+//  D1_min=def->defect_swap_min_TLSM[0][nu][1];
+//  D2_min=def->defect_swap_min_TLSM[0][nu][2];
+//  D3_min=def->defect_swap_min_TLSM[0][nu][3];
+//
+//  for(is=0; is<sizeh;is++){
+//    tr_local_rects[0].c[is]=0;
+//    tr_local_rects[1].c[is]=0;
+//  }
+//	#pragma acc update device(tr_local_rects[0:2])
+//
+//	#pragma acc kernels present(u) present(w) present(loc_rects) present(tr_local_rects)
+//	#pragma acc loop independent gang(STAPGANG3) 
+//  for(d3=D3_min; d3< D3_max; d3++) {
+//		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
+//    for(d2=D2_min; d2< D2_max; d2++) {
+//      for(d1=D1_min; d1< D1_max; d1++) {
+//				for(d0=D0_min; d0< D0_max; d0++) {
+//
+//					idxh = snum_acc(d0,d1,d2,d3);
+//					parity = (d0+d1+d2+d3) % 2;
+//
+//					if(d1==-1){parity = (d0+d2+d3) % 2; idxh=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];parity=!parity;}
+//					if(d2==-1){parity = (d0+d1+d3) % 2; idxh=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];parity=!parity;}
+//					if(d0==-1){parity = (d3+d1+d2) % 2; idxh=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];parity=!parity;}
+//					if(d3==-1){parity = (d0+d1+d2) % 2; idxh=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];parity=!parity;}
+//					int idxh1;
+//					if(d1==-2){parity = (d0+d2+d3) % 2; idxh1=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];idxh=nnm_openacc[idxh1][1][!parity]; }
+//					if(d2==-2){parity = (d0+d1+d3) % 2; idxh1=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];idxh=nnm_openacc[idxh1][2][!parity];}
+//					if(d0==-2){parity = (d3+d1+d2) % 2; idxh1=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];idxh=nnm_openacc[idxh1][0][!parity];}
+//					if(d3==-2){parity = (d0+d1+d2) % 2; idxh1=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];idxh=nnm_openacc[idxh1][3][!parity]; }
+//
+//					dir_muA = 2*mu +  parity;
+//					dir_nuB = 2*nu + !parity;
+//					dir_nuC = 2*nu +  parity;
+//					dir_muD = 2*mu +  parity;
+//					dir_nuE = 2*nu + !parity;
+//					dir_nuF = 2*nu +  parity;
+//
+//					idxpmu = nnp_openacc[idxh][mu][parity];       // r+mu
+//					idxpmupnu = nnp_openacc[idxpmu][nu][!parity]; // r+mu+nu
+//					idxpnu = nnp_openacc[idxh][nu][parity];       // r+nu
+//					idxpnupnu = nnp_openacc[idxpnu][nu][!parity]; // r+nu+nu
+//                        
+//					//            (D)
+//					//    r+2nu +<---+ r+mu+2nu
+//					//          |    ^
+//					//      (E) V    | (C)
+//					//     r+nu +    + r+mu+nu
+//					// nu       |    ^
+//					// ^    (F) V    | (B)
+//					// |        +--->+
+//					// |       r  (A)  r+mu
+//					// +---> mu
+//
+//					// rect 1x2 u
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&u[dir_muA],idxh,&u[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
+//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuF],idxh);                 // loc_rect = loc_rect * F
+//					d_complex ciao = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
+//
+//					// K_mu_nu_RECT3 1x2 u
+//					double K_mu_nu_RECT3;
+//					K_mu_nu_RECT3=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupnu])*(u[dir_muD].K.d[idxpnupnu])*(u[dir_nuE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
+//	  
+//					// rect 1x2 w
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
+//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
+//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
+//
+//					// K_mu_nu_RECT4 1x2 w
+//					double K_mu_nu_RECT4;
+//					K_mu_nu_RECT4=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupnu])*(w[dir_muD].K.d[idxpnupnu])*(w[dir_nuE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
+//
+//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT3-K_mu_nu_RECT4)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
+//				} // d0
+//      } // d1
+//    } // d2
+//  } // d3
+//
+//	#pragma acc kernels present(tr_local_rects)
+//	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
+//  for(t=0; t  < sizeh; t++) {
+//    res_R_p += creal(tr_local_rects[0].c[t]); // even sites rectangles
+//    res_R_p += creal(tr_local_rects[1].c[t]); // odd sites rectangles
+//  }
+//  res_R_p *= BETA_BY_THREE; // Delta_S_Symanzik = (beta/3) sum ( Delta_K_1x2 * Delta_Tr_Rect_1x2 + 1x2 ---> 2x1 )
+//  return res_R_p;
+//}
+//#endif
+
 // compute Delta_S = (beta/3) Sum [ Delta_K_rect_1x2 * Delta_Tr(rect)_1x2 + 1x2 ---> 2x1 ]
 #ifdef GAUGE_ACT_TLSM
-double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
-                                  __restrict const su3_soa * const w,
+double calc_S_Symanzik_defect(__restrict const su3_soa * const u,
                                   __restrict su3_soa * const loc_rects,
                                   dcomplex_soa * const tr_local_rects,
                                   const int mu, const int nu, defect_info * def)
@@ -550,7 +955,7 @@ double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
 	#pragma acc update device(tr_local_rects[0:2])
 
   // 2x1
-	#pragma acc kernels present(u) present(w) present(loc_rects) present(tr_local_rects)
+	#pragma acc kernels present(u) present(loc_rects) present(tr_local_rects)
 	#pragma acc loop independent gang(STAPGANG3)
   for(d3=D3_min; d3< D3_max; d3++) {
 		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
@@ -597,18 +1002,19 @@ double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
 					double K_mu_nu_RECT;
 					K_mu_nu_RECT=(u[dir_muA].K.d[idxh])*(u[dir_muB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupmu])*(u[dir_muD].K.d[idxpmupnu])*(u[dir_muE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
 
-					// rect 2x1 w
-					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muE],idxpnu);               // loc_rect = loc_rect * E
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-
-					// K_mu_nu_RECT 2x1 w 
-					double K_mu_nu_RECT2;
-					K_mu_nu_RECT2=(w[dir_muA].K.d[idxh])*(w[dir_muB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupmu])*(w[dir_muD].K.d[idxpmupnu])*(w[dir_muE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
-					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT-K_mu_nu_RECT2)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
+//					// rect 2x1 w
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
+//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muE],idxpnu);               // loc_rect = loc_rect * E
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
+//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
+//
+//					// K_mu_nu_RECT 2x1 w 
+//					double K_mu_nu_RECT2;
+//					K_mu_nu_RECT2=(w[dir_muA].K.d[idxh])*(w[dir_muB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupmu])*(w[dir_muD].K.d[idxpmupnu])*(w[dir_muE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
+//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT-K_mu_nu_RECT2)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
+					tr_local_rects[parity].c[idxh] += K_mu_nu_RECT*( creal(ciao)+cimag(ciao)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
 				} //d0
       } // d1
     } // d2
@@ -645,7 +1051,7 @@ double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
   }
 	#pragma acc update device(tr_local_rects[0:2])
 
-	#pragma acc kernels present(u) present(w) present(loc_rects) present(tr_local_rects)
+	#pragma acc kernels present(u) present(loc_rects) present(tr_local_rects)
 	#pragma acc loop independent gang(STAPGANG3) 
   for(d3=D3_min; d3< D3_max; d3++) {
 		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
@@ -701,23 +1107,25 @@ double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
 					double K_mu_nu_RECT3;
 					K_mu_nu_RECT3=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupnu])*(u[dir_muD].K.d[idxpnupnu])*(u[dir_nuE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
 	  
-					// rect 1x2 w
-					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
-					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-
-					// K_mu_nu_RECT4 1x2 w
-					double K_mu_nu_RECT4;
-					K_mu_nu_RECT4=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupnu])*(w[dir_muD].K.d[idxpnupnu])*(w[dir_nuE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
-
-					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT3-K_mu_nu_RECT4)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
+//					// rect 1x2 w
+//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
+//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
+//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
+//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
+//
+//					// K_mu_nu_RECT4 1x2 w
+//					double K_mu_nu_RECT4;
+//					K_mu_nu_RECT4=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupnu])*(w[dir_muD].K.d[idxpnupnu])*(w[dir_nuE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
+//
+//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT3-K_mu_nu_RECT4)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
+					tr_local_rects[parity].c[idxh] += K_mu_nu_RECT3*(creal(ciao)+cimag(ciao)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
 				} // d0
       } // d1
     } // d2
   } // d3
+  //TODO: fix comments
 
 	#pragma acc kernels present(tr_local_rects)
 	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
@@ -730,83 +1138,255 @@ double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
 }
 #endif
 
-//TODO: reimplement without explicit swap, but at the label level in world root
-int metro_SWAP(su3_soa ** conf_acc,
-               __restrict su3_soa * const loc_plaq,
-               dcomplex_soa * const tr_local_plaqs,
-							 int rep_indx1, int rep_indx2,defect_info * def, rep_info * hpt_params)
-{
+
+
+////TODO: reimplement without explicit swap, but at the label level in world root
+//int metro_SWAP(su3_soa ** conf_acc,
+//               __restrict su3_soa * const loc_plaq,
+//               dcomplex_soa * const tr_local_plaqs,
+//							 int rep_indx1, int rep_indx2,defect_info * def, rep_info * hpt_params)
+//{
+//  double p1,p2;
+//  double Delta_S_SWAP;
+//  int accepted = 0;
+//  Delta_S_SWAP = calc_Delta_S_soloopenacc_SWAP(conf_acc[rep_indx1],conf_acc[rep_indx2],loc_plaq,tr_local_plaqs,def);
+//  if(verbosity_lv>8 && 0==devinfo.myrank) printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n",rep_indx1, rep_indx2, Delta_S_SWAP);
+//  if(Delta_S_SWAP < 0) {
+//    accepted=1;
+//    if(verbosity_lv>8 && 0==devinfo.myrank) printf("DELTA_S_SWAP < 0 => swap accepted");
+//  }
+//  else {
+//		p1=exp(-Delta_S_SWAP);
+//		if(debug_settings.do_norandom_test) p2=0.0; // NORANDOM
+//		else { // NORMAL, RANDOM
+//			if(0==devinfo.myrank) p2=casuale();
+//#ifdef MULTIDEVICE
+//			MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
+//#endif
+//		}
+//		if(verbosity_lv>8 && 0==devinfo.myrank) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, p2);
+//		if (p2<p1) accepted=1;
+//	}
+//  if (accepted==1) replicas_swap(conf_acc[rep_indx1],conf_acc[rep_indx2], rep_indx1, rep_indx2, hpt_params);
+//  return accepted;
+//}
+
+int metro_SWAP_worldmaster(double Delta_S_SWAP){
   double p1,p2;
-  double Delta_S_SWAP;
   int accepted = 0;
-  Delta_S_SWAP = calc_Delta_S_soloopenacc_SWAP(conf_acc[rep_indx1],conf_acc[rep_indx2],loc_plaq,tr_local_plaqs,def);
-  if(verbosity_lv>8 && 0==devinfo.myrank) printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n",rep_indx1, rep_indx2, Delta_S_SWAP);
   if(Delta_S_SWAP < 0) {
     accepted=1;
-    if(verbosity_lv>8 && 0==devinfo.myrank) printf("DELTA_S_SWAP < 0 => swap accepted");
   }
   else {
 		p1=exp(-Delta_S_SWAP);
 		if(debug_settings.do_norandom_test) p2=0.0; // NORANDOM
 		else { // NORMAL, RANDOM
-			if(0==devinfo.myrank) p2=casuale();
-#ifdef MULTIDEVICE
-			MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
-#endif
+//			p2=casuale();
+//#ifdef MULTIDEVICE
+//			MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+//#endif
 		}
-		if(verbosity_lv>8 && 0==devinfo.myrank) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, p2);
+		if(verbosity_lv>8) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, p2);
 		if (p2<p1) accepted=1;
 	}
-  if (accepted==1) replicas_swap(conf_acc[rep_indx1],conf_acc[rep_indx2], rep_indx1, rep_indx2, hpt_params);
+//  if (accepted==1) replicas_swap(conf_acc[rep_indx1],conf_acc[rep_indx2], rep_indx1, rep_indx2, hpt_params);
   return accepted;
 }
 
-//TODO: reimplement without explicit swap, but at the label level in world root
-void All_Conf_SWAP( su3_soa ** conf_acc,
+////TODO: reimplement without explicit swap, but at the label level in world root
+//void All_Conf_SWAP( su3_soa ** conf_acc,
+//										__restrict su3_soa * const loc_plaq,
+//										dcomplex_soa * const tr_local_plaqs, 
+//										defect_info * def, 
+//										int* swap_num,
+//										int * all_swap_vet,
+//										int * acceptance_vet, rep_info * hpt_params){
+//
+//  double swap_order;
+//  int replicas_number = hpt_params->replicas_total_number;
+//
+//  if(0==devinfo.myrank){swap_order=casuale();}
+//
+//#ifdef MULTIDEVICE
+//  MPI_Bcast((void*) &swap_order,1,MPI_DOUBLE,0,devinfo.mpi_comm);
+//#endif
+//
+//  int accepted=0;
+//  int i_counter, j_counter;
+//   
+//  if(swap_order<=0.5){
+//		if (0==devinfo.myrank) printf("Swap order: 0->N_r-1\n");
+//
+//		for(i_counter=0;i_counter<replicas_number-1;i_counter++){
+//      if(verbosity_lv>4 && 0==devinfo.myrank) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
+//      accepted=metro_SWAP(conf_acc, loc_plaq, tr_local_plaqs, i_counter, i_counter+1, def, hpt_params);
+//			#pragma acc update device(conf_acc[0:replicas_number][0:8])
+//      *swap_num=*swap_num+1;
+//      all_swap_vet[i_counter]++;
+//      if (accepted==1) acceptance_vet[i_counter]++;
+//    }
+//  }
+//  else{
+//		if (0==devinfo.myrank) printf("Swap order: N_r-1->0\n");
+//
+//    for(i_counter=0;i_counter<replicas_number-1;i_counter++){
+//      if(verbosity_lv>4 && 0==devinfo.myrank) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
+//      accepted=metro_SWAP( conf_acc,loc_plaq,tr_local_plaqs, replicas_number-i_counter-1, replicas_number-i_counter-2, def, hpt_params);
+//			#pragma acc update device(conf_acc[0:replicas_number][0:8])      
+//      *swap_num=*swap_num+1;
+//      all_swap_vet[replicas_number-i_counter-2]++;
+//      if(accepted==1) acceptance_vet[replicas_number-i_counter-2]++;
+//    }
+//  }
+//}
+
+void manage_replica_swaps(
+                    su3_soa * tconf_acc,
 										__restrict su3_soa * const loc_plaq,
 										dcomplex_soa * const tr_local_plaqs, 
 										defect_info * def, 
-										int* swap_num,
+                    int* swap_num,
 										int * all_swap_vet,
 										int * acceptance_vet, rep_info * hpt_params){
-
-  double swap_order;
-  int replicas_number = hpt_params->replicas_total_number;
-
-  if(0==devinfo.myrank){swap_order=casuale();}
-
-#ifdef MULTIDEVICE
-  MPI_Bcast((void*) &swap_order,1,MPI_DOUBLE,0,devinfo.mpi_comm);
-#endif
-
-  int accepted=0;
-  int i_counter, j_counter;
-   
-  if(swap_order<=0.5){
-		if (0==devinfo.myrank) printf("Swap order: 0->N_r-1\n");
-
-		for(i_counter=0;i_counter<replicas_number-1;i_counter++){
-      if(verbosity_lv>4 && 0==devinfo.myrank) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
-      accepted=metro_SWAP(conf_acc, loc_plaq, tr_local_plaqs, i_counter, i_counter+1, def, hpt_params);
-			#pragma acc update device(conf_acc[0:replicas_number][0:8])
-      *swap_num=*swap_num+1;
-      all_swap_vet[i_counter]++;
-      if (accepted==1) acceptance_vet[i_counter]++;
+    double S_arr_prev[NREPLICAS];
+    double S_arr_next[NREPLICAS];
+    for(int r=0; r<NREPLICAS; ++r){
+      S_arr_prev[r]=0.0;
+      S_arr_next[r]=0.0;
     }
-  }
-  else{
-		if (0==devinfo.myrank) printf("Swap order: N_r-1->0\n");
 
-    for(i_counter=0;i_counter<replicas_number-1;i_counter++){
-      if(verbosity_lv>4 && 0==devinfo.myrank) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
-      accepted=metro_SWAP( conf_acc,loc_plaq,tr_local_plaqs, replicas_number-i_counter-1, replicas_number-i_counter-2, def, hpt_params);
-			#pragma acc update device(conf_acc[0:replicas_number][0:8])      
-      *swap_num=*swap_num+1;
-      all_swap_vet[replicas_number-i_counter-2]++;
-      if(accepted==1) acceptance_vet[replicas_number-i_counter-2]++;
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // maybe compute and send info for delta S
+    compute_S_of_replicas(tconf_acc, loc_plaq, tr_local_plaqs, def, &S_arr_prev[0]);
+
+
+    if(devinfo.myrank_world==0){
+      for(int r=0; r<NREPLICAS; ++r){
+        MPI_PRINTF1(" S_arr_prev[%d]=%lg\n",r,S_arr_prev[r]);
+      }
     }
-  }
+
+    // select relabeling and scatter coefficients to
+    // each mpirank
+      double swap_order;
+      int replicas_number = NREPLICAS;//hpt_params->replicas_total_number;
+
+    if (0==devinfo.myrank_world){
+      swap_order=casuale();
+    }
+    MPI_Bcast((void*)&swap_order,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+
+
+//#ifdef MULTIDEVICE
+//  MPI_Bcast((void*) &swap_order,1,MPI_DOUBLE,0,devinfo.mpi_comm);
+//#endif
+
+      int accepted=0;
+      int i_counter, j_counter;
+      int replicas_num_prev,replicas_num_next;
+      for(i_counter=0;i_counter<replicas_number-1;i_counter++){
+        if(swap_order<=0.5){ 
+          MPI_PRINTF0("Swap order: 0->N_r-1\n"); //
+          replicas_num_prev=i_counter;
+          replicas_num_next=i_counter+1;
+        }else{
+          MPI_PRINTF0("Swap order: N_r-1->0\n");
+          replicas_num_prev=replicas_number-i_counter-1;
+          replicas_num_next=replicas_number-i_counter-2;
+        }
+
+        if(verbosity_lv>4) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
+        //accepted=metro_SWAP(conf_acc,loc_plaq,tr_local_plaqs, replicas_num_prev, replicas_num_next, def, hpt_params);
+        
+        
+        //TODO: ensure that hpt_params->cr_vec is synced for all mpirank
+
+        //TODO: check whether one has to use a label filter for replicas somewhere
+        
+        // replicas_num_prev and replicas_num_next are tried for swap
+        if(replicas_num_prev==devinfo.replica_idx){
+          // set defect as next
+          init_k(tconf_acc,hpt_params->cr_vec[replicas_num_next],hpt_params->defect_boundary,rep->defect_coordinates,&def,1);
+        }
+        if(replicas_num_next==devinfo.replica_idx){
+          // set defect as prev
+          init_k(tconf_acc,hpt_params->cr_vec[replicas_num_prev],hpt_params->defect_boundary,rep->defect_coordinates,&def,1);
+        }
+
+      for(int r=0; r<NREPLICAS; ++r){
+        S_arr_next[r]=0.0;
+      }
+      compute_S_of_replicas(tconf_acc, loc_plaq, tr_local_plaqs, def, &S_arr_next[0]);
+
+
+      MPI_Barrier(MPI_COMM_WORLD); //XXX: maybe superfluous
+
+      if(devinfo.myrank_world==0){
+        for(int r=0; r<NREPLICAS; ++r){
+          MPI_PRINTF1("icounter: %d, S_arr_next[%d]=%lg\n",i_counter, r,S_arr_next[r]);
+        }
+
+
+        MPI_PRINTF1("All actions next[prev], next[next], prev[prev], prev[next]: %lf, %lf, %lf, %lf\n",
+            S_arr_next[replicas_num_prev], S_arr_next[replicas_num_next], 
+            S_arr_prev[replicas_num_prev], S_arr_prev[replicas_num_next])
+      }
+//      // All mpiranks access this  
+//      int do_perform_swap=1;
+
+      if (0==devinfo.myrank_world){
+        // compute acceptance:
+        double Delta_S_SWAP =  S_arr_next[replicas_num_prev]
+                              +S_arr_next[replicas_num_next]
+                              -S_arr_prev[replicas_num_prev]
+                              -S_arr_prev[replicas_num_next];
+        accepted=metro_SWAP_worldmaster(Delta_S_SWAP);
+        if(verbosity_lv>8) printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n",
+            replicas_num_prev, replicas_num_next, Delta_S_SWAP);
+
+        if(accepted){
+          int aux_label;
+          aux_label=hpt_params->label[replicas_num_prev];
+          hpt_params->label[replicas_num_prev] = hpt_params->label[replicas_num_next];
+          hpt_params->label[replicas_num_next] = aux_label;
+        }
+      }
+
+      //TODO: maybe remove it since superfluous
+      MPI_Bcast((void*)&(hpt_params->label[0]),NREPLICAS,MPI_INT,0,MPI_COMM_WORLD);
+//      MPI_Bcast((void*)&hpt_params->cr_vec[0],NREPLICAS,MPI_DOUBLE,0,MPI_COMM_WORLD);
+
+//      MPI_Barrier(MPI_COMM_WORLD);
+
+      if(!accepted && replicas_num_prev==devinfo.replica_idx){
+        // set defect as next
+        init_k(tconf_acc,hpt_params->cr_vec[replicas_num_prev],hpt_params->defect_boundary,rep->defect_coordinates,&def,1);
+      }
+      if(!accepted && replicas_num_next==devinfo.replica_idx){
+        // set defect as prev
+        init_k(tconf_acc,hpt_params->cr_vec[replicas_num_next],hpt_params->defect_boundary,rep->defect_coordinates,&def,1);
+      }
+
+      for(int r=0; r<NREPLICAS; ++r){
+        S_arr_prev[r]=0.0;
+      }
+      compute_S_of_replicas(tconf_acc, loc_plaq, tr_local_plaqs, def, &S_arr_prev[0]);
+
+//      #pragma acc update device(conf_acc[0:8])
+      *swap_num=*swap_num+1;
+      int replicas_num_fixed = (swap_order<=0.5)? replicas_num_prev :  replicas_num_next;
+      all_swap_vet[replicas_num_fixed]++;
+      if(accepted==1) acceptance_vet[replicas_num_fixed]++;
+
+      MPI_Barrier(MPI_COMM_WORLD); 
+    }
+
+    // receive scattered info
+
+    MPI_Barrier(MPI_COMM_WORLD);
 }
+
     
 void trasl_conf( __restrict const su3_soa *  const tconf_acc,
 								 __restrict const su3_soa *  const taux_conf){

--- a/src/OpenAcc/HPT_utilities.c
+++ b/src/OpenAcc/HPT_utilities.c
@@ -776,11 +776,17 @@ void manage_replica_swaps(
         // set defect as next
         MPI_PRINTF1("replica lab: %d gets coefficient %lf\n",rep_lab1,hpt_params->cr_vec[rep_lab2]);
         init_k(tconf_acc,hpt_params->cr_vec[rep_lab2],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+        if(devinfo.async_comm_gauge) init_k(&conf_acc[8],rep->cr_vec[rep_lab2],rep->defect_boundary,rep->defect_coordinates,&def,1);
+#endif
       }
       if(rep_lab2==hpt_params->label[devinfo.replica_idx]){
         // set defect as prev
         MPI_PRINTF1("replica lab: %d gets coefficient %lf\n",rep_lab2,hpt_params->cr_vec[rep_lab1]);
         init_k(tconf_acc,hpt_params->cr_vec[rep_lab1],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+        if(devinfo.async_comm_gauge) init_k(&conf_acc[8],rep->cr_vec[rep_lab1],rep->defect_boundary,rep->defect_coordinates,&def,1);
+#endif
       }
       //TODO: possibly optimize by updating only defect info
       #pragma acc update device(tconf_acc[0:alloc_info.conf_acc_size])
@@ -841,10 +847,16 @@ void manage_replica_swaps(
       if(!accepted && rep_lab1==hpt_params->label[devinfo.replica_idx]){
         // set defect as next
         init_k(tconf_acc,hpt_params->cr_vec[rep_lab1],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+        if(devinfo.async_comm_gauge) init_k(&conf_acc[8],rep->cr_vec[rep_lab1],rep->defect_boundary,rep->defect_coordinates,&def,1);
+#endif
       }
       if(!accepted && rep_lab2==hpt_params->label[devinfo.replica_idx]){
         // set defect as prev
         init_k(tconf_acc,hpt_params->cr_vec[rep_lab2],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+        if(devinfo.async_comm_gauge) init_k(&conf_acc[8],rep->cr_vec[rep_lab2],rep->defect_boundary,rep->defect_coordinates,&def,1);
+#endif
       }
       //TODO: possibly optimize by updating only defect info
       #pragma acc update device(tconf_acc[0:alloc_info.conf_acc_size])

--- a/src/OpenAcc/HPT_utilities.c
+++ b/src/OpenAcc/HPT_utilities.c
@@ -388,7 +388,7 @@ double calc_Delta_S_soloopenacc_SWAP(
   }
 #ifdef MULTIDEVICE
   MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
   total_result = result;
 #endif
@@ -750,7 +750,7 @@ int metro_SWAP(su3_soa ** conf_acc,
 		else { // NORMAL, RANDOM
 			if(0==devinfo.myrank) p2=casuale();
 #ifdef MULTIDEVICE
-			MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+			MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
 #endif
 		}
 		if(verbosity_lv>8 && 0==devinfo.myrank) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, p2);
@@ -774,7 +774,7 @@ void All_Conf_SWAP( su3_soa ** conf_acc,
   if(0==devinfo.myrank){swap_order=casuale();}
 
 #ifdef MULTIDEVICE
-  MPI_Bcast((void*) &swap_order,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+  MPI_Bcast((void*) &swap_order,1,MPI_DOUBLE,0,devinfo.mpi_comm);
 #endif
 
   int accepted=0;
@@ -821,7 +821,7 @@ void trasl_conf( __restrict const su3_soa *  const tconf_acc,
     
   if(0==devinfo.myrank){dir0=casuale();}
 #ifdef MULTIDEVICE
-  MPI_Bcast((void*) &dir0,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+  MPI_Bcast((void*) &dir0,1,MPI_DOUBLE,0,devinfo.mpi_comm);
   if(verbosity_lv>4)
     printf("MPI%02d dir0 : %f \n",devinfo.myrank,dir0);
 #endif

--- a/src/OpenAcc/HPT_utilities.c
+++ b/src/OpenAcc/HPT_utilities.c
@@ -730,6 +730,7 @@ double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
 }
 #endif
 
+//TODO: reimplement without explicit swap, but at the label level in world root
 int metro_SWAP(su3_soa ** conf_acc,
                __restrict su3_soa * const loc_plaq,
                dcomplex_soa * const tr_local_plaqs,
@@ -760,6 +761,7 @@ int metro_SWAP(su3_soa ** conf_acc,
   return accepted;
 }
 
+//TODO: reimplement without explicit swap, but at the label level in world root
 void All_Conf_SWAP( su3_soa ** conf_acc,
 										__restrict su3_soa * const loc_plaq,
 										dcomplex_soa * const tr_local_plaqs, 

--- a/src/OpenAcc/HPT_utilities.c
+++ b/src/OpenAcc/HPT_utilities.c
@@ -202,7 +202,7 @@ void init_k(su3_soa * conf, double c_r, int def_axis, int * def_vec, defect_info
       }
 
       // Wilson case
-      // 1x1 plaq: when computing Delta_S_SWAP_Wilson on the plane (mu,nu) (with mu=def_axis), must include contribution from x+nu € def sites => min[nu][nu] -= 1
+      // 1x1 plaq: when computing S_SWAP_Wilson on the plane (mu,nu) (with mu=def_axis), must include contribution from x+nu € def sites => min[nu][nu] -= 1
       def->defect_swap_min[0][0] -= 1;
       def->defect_swap_min[1][1] -= 1;
       def->defect_swap_min[2][2] -= 1;
@@ -324,35 +324,6 @@ void printing_k_mu(su3_soa * conf){
   }
 }
 
-//// swap conf pointers for a given couple
-//void replicas_swap(su3_soa * conf1, su3_soa * conf2, int lab1, int lab2, rep_info * hpt_params){
-//  vec3_soa  aux;
-//  int aux_label;
-//  int mu=0;
-//
-//	// swap labels
-//  aux_label=hpt_params->label[lab1];
-//  hpt_params->label[lab1] = hpt_params->label[lab2];
-//  hpt_params->label[lab2] = aux_label;
-//
-//  for(mu=0;mu<8;mu++){
-//    // swap r0
-//    aux=conf1[mu].r0;
-//    conf1[mu].r0=conf2[mu].r0;
-//    conf2[mu].r0=aux;
-//        
-//    // swap r1
-//    aux=conf1[mu].r1;
-//    conf1[mu].r1=conf2[mu].r1;
-//    conf2[mu].r1=aux;
-//        
-//    // swap r2
-//    aux=conf1[mu].r2;
-//    conf1[mu].r2=conf2[mu].r2;
-//    conf2[mu].r2=aux;
-//  }
-//}
-
 // print conf labels
 void label_print(rep_info * hpt_params, FILE *file, int step_number){
 
@@ -363,38 +334,6 @@ void label_print(rep_info * hpt_params, FILE *file, int step_number){
   }
   fprintf(file,"\n");
 }
-
-//double calc_Delta_S_soloopenacc_SWAP(
-//																		 __restrict  su3_soa * const tconf_acc,
-//																		 __restrict  su3_soa * const tconf_acc2,
-//																		 __restrict su3_soa * const local_plaqs,
-//																		 dcomplex_soa * const tr_local_plaqs,defect_info * def)
-//{
-//  double result=0.0;
-//  double total_result=0.0;
-//  int mu,nu;
-//  mu=def->def_axis_mapped;
-//  int counter=0;
-//
-//  for(counter=0;counter<3;counter++){
-//    nu=def->def_mapped_perp_dir[counter];
-//		
-//		// result = C_0 * delta_S_plaq_1x1
-//    result += C_ZERO * calc_Delta_S_Wilson_SWAP(tconf_acc,tconf_acc2,local_plaqs,tr_local_plaqs,mu,nu,def);
-//#ifdef GAUGE_ACT_TLSM
-//		// result + C_1 * ( delta_S_rect_1x2 + delta_S_rect_2x1 )
-//    result += C_ONE * calc_Delta_S_Symanzik_SWAP(tconf_acc,tconf_acc2,local_plaqs,tr_local_plaqs,mu,nu,def);
-//#endif
-//  }
-//#ifdef MULTIDEVICE
-//  MPI_Allreduce((void*)&result,(void*)&total_result,
-//								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
-//#else
-//  total_result = result;
-//#endif
-//  return total_result;
-//}
-
 
 double calc_S_soloopenacc_defect(__restrict  su3_soa * const tconf_acc,
 																 __restrict su3_soa * const local_plaqs,
@@ -432,163 +371,31 @@ void compute_S_of_replicas(
                         dcomplex_soa * const tr_local_plaqs,
                         defect_info * def,
                         double * S_arr){
-  // compute and write on 
-//  if(devinfo.myrank==0){
-//    // like this:
-////#ifdef MULTIDEVICE
-////  MPI_Allreduce((void*)&result,(void*)&total_result,
-////								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
-////#else
-//    S_arr_prev[devinfo.replica_idx]=devinfo.replica_idx;
-//    S_arr_next[devinfo.replica_idx]=devinfo.replica_idx;
-//  }
-
-  // alternative version:
+  
   // reduce on all world ranks
-  //TODO: replace with true computations
   double S_val[NREPLICAS];
   for(int r=0; r<NREPLICAS; ++r){
     S_val[r]=0.0;
   }
-
   //double S_prev_loc=(double)(devinfo.nranks*devinfo.replica_idx+devinfo.myrank); 
   double S_loc=calc_S_soloopenacc_defect(tconf_acc,local_plaq, tr_local_plaqs,def);
-
 
   // master decides swap attempts and send command of actions recomputation
   
   MPI_Barrier(MPI_COMM_WORLD);
 
-//XXX debug:  double S_loc=(double)(devinfo.nranks_world*devinfo.replica_idx+devinfo.myrank_world);
 
-//  MPI_PRINTF1("S_prev_loc:%lf\n",S_prev_loc);
-//  MPI_PRINTF1("S_next_loc:%lf\n",S_next_loc);
   int rep_idx=devinfo.replica_idx;
 
   MPI_Reduce((void*)&S_loc,(void*)&(S_val[rep->label[rep_idx]]), 1,MPI_DOUBLE, MPI_SUM, 0, devinfo.mpi_comm);
-//  MPI_Reduce((void*)&S_next_loc,(void*)&S_next[rep_idx], 1,MPI_DOUBLE, MPI_SUM, 0, devinfo.mpi_comm);
-//  MPI_PRINTF1("S_prev:%lf\n",S_prev);
-//  MPI_PRINTF1("S_next:%lf\n",S_next);
   
   for(int lab=0; lab<NREPLICAS; ++lab){
     MPI_Reduce(&S_val[lab], &S_arr[lab], 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
-//    MPI_Reduce(&S_next[r], &S_arr_next[r], 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
   }
 }
 
-//// compute delta_S_plaq = (beta/3) * sum delta_K_1x1 delta_Tr(plaq_1x1)
-//double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
-//                                __restrict const su3_soa * const w,
-//                                __restrict su3_soa * const loc_plaq,
-//                                dcomplex_soa * const tr_local_plaqs,
-//                                const int mu, const int nu, defect_info * def)
-//{
-//  double K_mu_nu;
-//  double K_mu_nu2;
-//  int d0,d1,d2,d3;
-//  int i;
-//
-//  int D0_min,D1_min,D2_min,D3_min;
-//  int D0_max,D1_max,D2_max,D3_max;
-//
-//  D0_min=def->defect_swap_min[nu][0];
-//  D1_min=def->defect_swap_min[nu][1];
-//  D2_min=def->defect_swap_min[nu][2];
-//  D3_min=def->defect_swap_min[nu][3];
-//
-//  D0_max=def->defect_swap_max[nu][0];
-//  D1_max=def->defect_swap_max[nu][1];
-//  D2_max=def->defect_swap_max[nu][2];
-//  D3_max=def->defect_swap_max[nu][3];
-//
-//  for(i=0; i<sizeh;i++){
-//    tr_local_plaqs[0].c[i]=0;
-//    tr_local_plaqs[1].c[i]=0;
-//  }
-//	#pragma acc update device(tr_local_plaqs[0:2])
-//
-//	#pragma acc kernels present(u) present(w) present(loc_plaq) present(tr_local_plaqs)
-//	#pragma acc loop independent gang(STAPGANG3)
-//  for(d3=D3_min; d3<D3_max; d3++) {
-//		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
-//    for(d2=D2_min; d2<D2_max; d2++) {
-//      for(d1=D1_min; d1<D1_max; d1++) {
-//				for(d0=D0_min; d0<D0_max; d0++) {
-//                
-//					int idxh,idxpmu,idxpnu;
-//					int parity;
-//					int dir_muA,dir_nuB;
-//					int dir_muC,dir_nuD;
-//                
-//					idxh = snum_acc(d0,d1,d2,d3); // site r
-//					parity = (d0+d1+d2+d3) % 2;
-//
-//					// impose periodic boundary conditions
-//					if(d1==-1){parity = (d0+d2+d3) % 2; idxh=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];parity=!parity;}
-//					if(d2==-1){parity = (d0+d1+d3) % 2; idxh=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];parity=!parity;}
-//					if(d0==-1){parity = (d3+d1+d2) % 2; idxh=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];parity=!parity;}
-//					if(d3==-1){parity = (d0+d1+d2) % 2; idxh=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];parity=!parity;}
-//                
-//					dir_muA = 2*mu +  parity;
-//					dir_muC = 2*mu + !parity;
-//					idxpmu = nnp_openacc[idxh][mu][parity]; // r+mu
-//                
-//					dir_nuB = 2*nu + !parity;
-//					dir_nuD = 2*nu +  parity;
-//					idxpnu = nnp_openacc[idxh][nu][parity]; // r+nu
-//                
-//					//       r+nu (C)  r+mu+nu
-//					//          +<---+
-//					// nu       |    ^
-//					// ^    (D) V    | (B)
-//					// |        +--->+
-//					// |       r  (A)  r+mu
-//					// +---> mu
-//                
-//					// plaquette u
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&u[dir_muA],idxh,&u[dir_nuB],idxpmu,&loc_plaq[parity],idxh);  // loc_plaq = A * B
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&u[dir_muC],idxpnu);              // loc_plaq = loc_plaq * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&u[dir_nuD],idxh);                // loc_plaq = loc_plaq * D
-//                
-//					d_complex ciao = matrix_trace_absent_stag_phase(&loc_plaq[parity],idxh); // tr(plaq_u)
-//					tr_local_plaqs[parity].c[idxh] = creal(ciao)+cimag(ciao)*I;
-//                
-//					// K_{mu nu} u
-//					K_mu_nu=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_muC].K.d[idxpnu])*(u[dir_nuD].K.d[idxh]);
-//                
-//					// plaquette w
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_plaq[parity],idxh);  // loc_plaq = A * B
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&w[dir_muC],idxpnu);              // loc_plaq = loc_plaq * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_plaq[parity],idxh,&w[dir_nuD],idxh);                // loc_plaq = loc_plaq * D
-//                
-//					// K_{mu nu} w
-//					K_mu_nu2=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_muC].K.d[idxpnu])*(w[dir_nuD].K.d[idxh]);
-//                
-//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_plaq[parity],idxh);
-//                
-//					tr_local_plaqs[parity].c[idxh] = tr_local_plaqs[parity].c[idxh]-creal(ciao2)-cimag(ciao2)*I; // tr(plaq)_u - tr(plaq)_w 
-//					tr_local_plaqs[parity].c[idxh] = (K_mu_nu-K_mu_nu2)*tr_local_plaqs[parity].c[idxh]; // Delta_K * Delta_Tr_plaq = - Delta_S
-//				} // d0  
-//      } // d1
-//    } // d2
-//  } // d3
-//
-//  double res_R_p = 0.0;
-//  double res_I_p = 0.0;
-//  double resR = 0.0;
-//  int t;
-//
-//	#pragma acc kernels present(tr_local_plaqs)
-//	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
-//  for(t=0; t<sizeh; t++) {
-//    res_R_p += creal(tr_local_plaqs[0].c[t]); // even sites plaquettes
-//    res_R_p += creal(tr_local_plaqs[1].c[t]); // odd sites plaquettes
-//  }
-//  res_R_p *= BETA_BY_THREE; // Delta_S = (beta/3) Sum Delta_K * Delta_Tr_plaq
-//  return res_R_p;
-//}
 
-// compute delta_S_plaq = (beta/3) * sum delta_K_1x1 delta_Tr(plaq_1x1)
+// compute S_plaq = (beta/3) * sum K_1x1 Tr(plaq_1x1)
 double calc_S_Wilson_defect(__restrict const su3_soa * const u,
                               __restrict su3_soa * const loc_plaq,
                               dcomplex_soa * const tr_local_plaqs,
@@ -685,234 +492,12 @@ double calc_S_Wilson_defect(__restrict const su3_soa * const u,
     res_R_p += creal(tr_local_plaqs[0].c[t]); // even sites plaquettes
     res_R_p += creal(tr_local_plaqs[1].c[t]); // odd sites plaquettes
   }
-  res_R_p *= BETA_BY_THREE; // Delta_S = (beta/3) Sum Delta_K * Delta_Tr_plaq
+  res_R_p *= BETA_BY_THREE; // S = (beta/3) Sum K * Tr_plaq
   return res_R_p;
 }
 
-//// compute Delta_S = (beta/3) Sum [ Delta_K_rect_1x2 * Delta_Tr(rect)_1x2 + 1x2 ---> 2x1 ]
-//#ifdef GAUGE_ACT_TLSM
-//double calc_Delta_S_Symanzik_SWAP(__restrict const su3_soa * const u,
-//                                  __restrict const su3_soa * const w,
-//                                  __restrict su3_soa * const loc_rects,
-//                                  dcomplex_soa * const tr_local_rects,
-//                                  const int mu, const int nu, defect_info * def)
-//{
-//  double K_mu_nu;
-//  double K_mu_nu2;
-//  int d0, d1, d2, d3;
-//  int D0_min,D1_min,D2_min,D3_min;
-//  int D0_max,D1_max,D2_max,D3_max;
-//
-//  // min and max init
-//  D0_max=def->defect_swap_max_TLSM[1][nu][0];
-//  D1_max=def->defect_swap_max_TLSM[1][nu][1];
-//  D2_max=def->defect_swap_max_TLSM[1][nu][2];
-//  D3_max=def->defect_swap_max_TLSM[1][nu][3];
-//
-//  D0_min=def->defect_swap_min_TLSM[1][nu][0];
-//  D1_min=def->defect_swap_min_TLSM[1][nu][1];
-//  D2_min=def->defect_swap_min_TLSM[1][nu][2];
-//  D3_min=def->defect_swap_min_TLSM[1][nu][3];
-//
-//  int idxh,idxpmu,idxpnu;
-//  int parity;
-//  int dir_muA,dir_nuB;
-//  int dir_muC,dir_nuD;
-//
-//  int dir_muB,dir_muD,dir_nuC;
-//  int dir_muE,dir_nuF,dir_nuE;
-//  int idxpmupmu,idxpmupnu; // 2x1
-//  int idxpnupnu; // 1x2
-//
-//  int is;
-//  for(is=0; is<sizeh;is++){
-//    tr_local_rects[0].c[is]=0;
-//    tr_local_rects[1].c[is]=0;
-//  }
-//	#pragma acc update device(tr_local_rects[0:2])
-//
-//  // 2x1
-//	#pragma acc kernels present(u) present(w) present(loc_rects) present(tr_local_rects)
-//	#pragma acc loop independent gang(STAPGANG3)
-//  for(d3=D3_min; d3< D3_max; d3++) {
-//		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
-//    for(d2=D2_min; d2< D2_max; d2++) {
-//      for(d1=D1_min; d1< D1_max; d1++) {
-//				for(d0=D0_min; d0< D0_max; d0++) {
-//
-//					idxh = snum_acc(d0,d1,d2,d3);
-//					parity = (d0+d1+d2+d3) % 2; 
-//
-//					if(d1==-1){parity = (d0+d2+d3) % 2; idxh=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];parity=!parity;}
-//					if(d2==-1){parity = (d0+d1+d3) % 2; idxh=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];parity=!parity;}
-//					if(d0==-1){parity = (d3+d1+d2) % 2; idxh=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];parity=!parity;}
-//					if(d3==-1){parity = (d0+d1+d2) % 2; idxh=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];parity=!parity;}
-//
-//					dir_muA = 2*mu +  parity;
-//					dir_muB = 2*mu + !parity;
-//					dir_nuC = 2*nu +  parity;
-//					dir_muD = 2*mu +  parity;
-//					dir_muE = 2*mu + !parity;
-//					dir_nuF = 2*nu +  parity;
-//					idxpmu = nnp_openacc[idxh][mu][parity]; // r+mu
-//					idxpmupmu = nnp_openacc[idxpmu][mu][!parity]; // r+2mu
-//					idxpmupnu = nnp_openacc[idxpmu][nu][!parity];// r+mu+nu
-//					idxpnu = nnp_openacc[idxh][nu][parity]; // r+nu
-//
-//					//       r+nu r+mu+nu r+2mu+nu
-//					//          +<---+<---+
-//					// nu       | (E) (D) ^
-//					// ^    (F) V (A) (B) |  (C)
-//					// |        +--->+--->+
-//					// |       r   r+mu r+2mu
-//					// +---> mu
-//
-//					// rect 2x1 u
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&u[dir_muA],idxh,&u[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_muE],idxpnu);               // loc_rect = loc_rect * E
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-//					d_complex ciao = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-//
-//					// K_mu_nu_RECT 2x1 u
-//					double K_mu_nu_RECT;
-//					K_mu_nu_RECT=(u[dir_muA].K.d[idxh])*(u[dir_muB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupmu])*(u[dir_muD].K.d[idxpmupnu])*(u[dir_muE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
-//
-//					// rect 2x1 w
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muE],idxpnu);               // loc_rect = loc_rect * E
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-//
-//					// K_mu_nu_RECT 2x1 w 
-//					double K_mu_nu_RECT2;
-//					K_mu_nu_RECT2=(w[dir_muA].K.d[idxh])*(w[dir_muB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupmu])*(w[dir_muD].K.d[idxpmupnu])*(w[dir_muE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
-//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT-K_mu_nu_RECT2)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
-//				} //d0
-//      } // d1
-//    } // d2
-//  } // d3
-//
-//  double res_R_p = 0.0;
-//  double res_I_p = 0.0;
-//  double resR = 0.0;
-//  int t;
-//
-//	#pragma acc kernels present(tr_local_rects)
-//	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
-//  for(t=0; t  < sizeh; t++) {
-//    res_R_p += creal(tr_local_rects[0].c[t]); // even sites rectangles
-//    res_R_p += creal(tr_local_rects[1].c[t]); // odd sites reactangles
-//  }
-//
-//  // 1x2
-//  // min and max init
-//  int idxh1;
-//  D0_max=def->defect_swap_max_TLSM[0][nu][0];
-//  D1_max=def->defect_swap_max_TLSM[0][nu][1];
-//  D2_max=def->defect_swap_max_TLSM[0][nu][2];
-//  D3_max=def->defect_swap_max_TLSM[0][nu][3];
-//
-//  D0_min=def->defect_swap_min_TLSM[0][nu][0];
-//  D1_min=def->defect_swap_min_TLSM[0][nu][1];
-//  D2_min=def->defect_swap_min_TLSM[0][nu][2];
-//  D3_min=def->defect_swap_min_TLSM[0][nu][3];
-//
-//  for(is=0; is<sizeh;is++){
-//    tr_local_rects[0].c[is]=0;
-//    tr_local_rects[1].c[is]=0;
-//  }
-//	#pragma acc update device(tr_local_rects[0:2])
-//
-//	#pragma acc kernels present(u) present(w) present(loc_rects) present(tr_local_rects)
-//	#pragma acc loop independent gang(STAPGANG3) 
-//  for(d3=D3_min; d3< D3_max; d3++) {
-//		#pragma acc loop independent tile(STAPTILE0,STAPTILE1,STAPTILE2)
-//    for(d2=D2_min; d2< D2_max; d2++) {
-//      for(d1=D1_min; d1< D1_max; d1++) {
-//				for(d0=D0_min; d0< D0_max; d0++) {
-//
-//					idxh = snum_acc(d0,d1,d2,d3);
-//					parity = (d0+d1+d2+d3) % 2;
-//
-//					if(d1==-1){parity = (d0+d2+d3) % 2; idxh=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];parity=!parity;}
-//					if(d2==-1){parity = (d0+d1+d3) % 2; idxh=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];parity=!parity;}
-//					if(d0==-1){parity = (d3+d1+d2) % 2; idxh=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];parity=!parity;}
-//					if(d3==-1){parity = (d0+d1+d2) % 2; idxh=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];parity=!parity;}
-//					int idxh1;
-//					if(d1==-2){parity = (d0+d2+d3) % 2; idxh1=nnm_openacc[snum_acc(d0,0,d2,d3)][1][parity];idxh=nnm_openacc[idxh1][1][!parity]; }
-//					if(d2==-2){parity = (d0+d1+d3) % 2; idxh1=nnm_openacc[snum_acc(d0,d1,0,d3)][2][parity];idxh=nnm_openacc[idxh1][2][!parity];}
-//					if(d0==-2){parity = (d3+d1+d2) % 2; idxh1=nnm_openacc[snum_acc(0,d1,d2,d3)][0][parity];idxh=nnm_openacc[idxh1][0][!parity];}
-//					if(d3==-2){parity = (d0+d1+d2) % 2; idxh1=nnm_openacc[snum_acc(d0,d1,d2,0)][3][parity];idxh=nnm_openacc[idxh1][3][!parity]; }
-//
-//					dir_muA = 2*mu +  parity;
-//					dir_nuB = 2*nu + !parity;
-//					dir_nuC = 2*nu +  parity;
-//					dir_muD = 2*mu +  parity;
-//					dir_nuE = 2*nu + !parity;
-//					dir_nuF = 2*nu +  parity;
-//
-//					idxpmu = nnp_openacc[idxh][mu][parity];       // r+mu
-//					idxpmupnu = nnp_openacc[idxpmu][nu][!parity]; // r+mu+nu
-//					idxpnu = nnp_openacc[idxh][nu][parity];       // r+nu
-//					idxpnupnu = nnp_openacc[idxpnu][nu][!parity]; // r+nu+nu
-//                        
-//					//            (D)
-//					//    r+2nu +<---+ r+mu+2nu
-//					//          |    ^
-//					//      (E) V    | (C)
-//					//     r+nu +    + r+mu+nu
-//					// nu       |    ^
-//					// ^    (F) V    | (B)
-//					// |        +--->+
-//					// |       r  (A)  r+mu
-//					// +---> mu
-//
-//					// rect 1x2 u
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&u[dir_muA],idxh,&u[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&u[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-//					d_complex ciao = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-//
-//					// K_mu_nu_RECT3 1x2 u
-//					double K_mu_nu_RECT3;
-//					K_mu_nu_RECT3=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupnu])*(u[dir_muD].K.d[idxpnupnu])*(u[dir_nuE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
-//	  
-//					// rect 1x2 w
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-//
-//					// K_mu_nu_RECT4 1x2 w
-//					double K_mu_nu_RECT4;
-//					K_mu_nu_RECT4=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupnu])*(w[dir_muD].K.d[idxpnupnu])*(w[dir_nuE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
-//
-//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT3-K_mu_nu_RECT4)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
-//				} // d0
-//      } // d1
-//    } // d2
-//  } // d3
-//
-//	#pragma acc kernels present(tr_local_rects)
-//	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
-//  for(t=0; t  < sizeh; t++) {
-//    res_R_p += creal(tr_local_rects[0].c[t]); // even sites rectangles
-//    res_R_p += creal(tr_local_rects[1].c[t]); // odd sites rectangles
-//  }
-//  res_R_p *= BETA_BY_THREE; // Delta_S_Symanzik = (beta/3) sum ( Delta_K_1x2 * Delta_Tr_Rect_1x2 + 1x2 ---> 2x1 )
-//  return res_R_p;
-//}
-//#endif
 
-// compute Delta_S = (beta/3) Sum [ Delta_K_rect_1x2 * Delta_Tr(rect)_1x2 + 1x2 ---> 2x1 ]
+// compute S = (beta/3) Sum [ K_rect_1x2 * Tr(rect)_1x2 + 1x2 ---> 2x1 ]
 #ifdef GAUGE_ACT_TLSM
 double calc_S_Symanzik_defect(__restrict const su3_soa * const u,
                                   __restrict su3_soa * const loc_rects,
@@ -1001,19 +586,7 @@ double calc_S_Symanzik_defect(__restrict const su3_soa * const u,
 					double K_mu_nu_RECT;
 					K_mu_nu_RECT=(u[dir_muA].K.d[idxh])*(u[dir_muB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupmu])*(u[dir_muD].K.d[idxpmupnu])*(u[dir_muE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
 
-//					// rect 2x1 w
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_muB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupmu);                 // loc_rect = loc_rect * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpmupnu);            // loc_rect = loc_rect * D
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muE],idxpnu);               // loc_rect = loc_rect * E
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-//
-//					// K_mu_nu_RECT 2x1 w 
-//					double K_mu_nu_RECT2;
-//					K_mu_nu_RECT2=(w[dir_muA].K.d[idxh])*(w[dir_muB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupmu])*(w[dir_muD].K.d[idxpmupnu])*(w[dir_muE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
-//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT-K_mu_nu_RECT2)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
-					tr_local_rects[parity].c[idxh] += K_mu_nu_RECT*( creal(ciao)+cimag(ciao)*I); // Delta_K_2x1 * Delta_Tr_rect_2x1 = -Delta_S_2x1
+					tr_local_rects[parity].c[idxh] += K_mu_nu_RECT*( creal(ciao)+cimag(ciao)*I); // K_2x1 * Tr_rect_2x1 = -S_2x1
 				} //d0
       } // d1
     } // d2
@@ -1106,25 +679,11 @@ double calc_S_Symanzik_defect(__restrict const su3_soa * const u,
 					double K_mu_nu_RECT3;
 					K_mu_nu_RECT3=(u[dir_muA].K.d[idxh])*(u[dir_nuB].K.d[idxpmu])*(u[dir_nuC].K.d[idxpmupnu])*(u[dir_muD].K.d[idxpnupnu])*(u[dir_nuE].K.d[idxpnu])*(u[dir_nuF].K.d[idxh]);
 	  
-//					// rect 1x2 w
-//					mat1_times_mat2_into_mat3_absent_stag_phases(&w[dir_muA],idxh,&w[dir_nuB],idxpmu,&loc_rects[parity],idxh);   // loc_rect = A * B
-//					mat1_times_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuC],idxpmupnu);                 // loc_rect = loc_rect * C
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_muD],idxpnupnu);            // loc_rect = loc_rect * D
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuE],idxpnu);               // loc_rect = loc_rect * E
-//					mat1_times_conj_mat2_into_mat1_absent_stag_phases(&loc_rects[parity],idxh,&w[dir_nuF],idxh);                 // loc_rect = loc_rect * F
-//					d_complex ciao2 = matrix_trace_absent_stag_phase(&loc_rects[parity],idxh);
-//
-//					// K_mu_nu_RECT4 1x2 w
-//					double K_mu_nu_RECT4;
-//					K_mu_nu_RECT4=(w[dir_muA].K.d[idxh])*(w[dir_nuB].K.d[idxpmu])*(w[dir_nuC].K.d[idxpmupnu])*(w[dir_muD].K.d[idxpnupnu])*(w[dir_nuE].K.d[idxpnu])*(w[dir_nuF].K.d[idxh]);
-//
-//					tr_local_rects[parity].c[idxh] += (K_mu_nu_RECT3-K_mu_nu_RECT4)*( creal(ciao)+cimag(ciao)*I-creal(ciao2)-cimag(ciao2)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
-					tr_local_rects[parity].c[idxh] += K_mu_nu_RECT3*(creal(ciao)+cimag(ciao)*I); // Delta_K_1x2 * Delta_Tr_rect_1x2 = - Delta_S_1x2
+					tr_local_rects[parity].c[idxh] += K_mu_nu_RECT3*(creal(ciao)+cimag(ciao)*I); // K_1x2 * Tr_rect_1x2 = - S_1x2
 				} // d0
       } // d1
     } // d2
   } // d3
-  //TODO: fix comments
 
 	#pragma acc kernels present(tr_local_rects)
 	#pragma acc loop reduction(+:res_R_p) reduction(+:res_I_p)
@@ -1132,43 +691,13 @@ double calc_S_Symanzik_defect(__restrict const su3_soa * const u,
     res_R_p += creal(tr_local_rects[0].c[t]); // even sites rectangles
     res_R_p += creal(tr_local_rects[1].c[t]); // odd sites rectangles
   }
-  res_R_p *= BETA_BY_THREE; // Delta_S_Symanzik = (beta/3) sum ( Delta_K_1x2 * Delta_Tr_Rect_1x2 + 1x2 ---> 2x1 )
+  res_R_p *= BETA_BY_THREE; // S_Symanzik = (beta/3) sum ( K_1x2 * Tr_Rect_1x2 + 1x2 ---> 2x1 )
   return res_R_p;
 }
 #endif
 
 
 
-////TODO: reimplement without explicit swap, but at the label level in world root
-//int metro_SWAP(su3_soa ** conf_acc,
-//               __restrict su3_soa * const loc_plaq,
-//               dcomplex_soa * const tr_local_plaqs,
-//							 int rep_indx1, int rep_indx2,defect_info * def, rep_info * hpt_params)
-//{
-//  double p1,p2;
-//  double Delta_S_SWAP;
-//  int accepted = 0;
-//  Delta_S_SWAP = calc_Delta_S_soloopenacc_SWAP(conf_acc[rep_indx1],conf_acc[rep_indx2],loc_plaq,tr_local_plaqs,def);
-//  if(verbosity_lv>8 && 0==devinfo.myrank) printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n",rep_indx1, rep_indx2, Delta_S_SWAP);
-//  if(Delta_S_SWAP < 0) {
-//    accepted=1;
-//    if(verbosity_lv>8 && 0==devinfo.myrank) printf("DELTA_S_SWAP < 0 => swap accepted");
-//  }
-//  else {
-//		p1=exp(-Delta_S_SWAP);
-//		if(debug_settings.do_norandom_test) p2=0.0; // NORANDOM
-//		else { // NORMAL, RANDOM
-//			if(0==devinfo.myrank) p2=casuale();
-//#ifdef MULTIDEVICE
-//			MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
-//#endif
-//		}
-//		if(verbosity_lv>8 && 0==devinfo.myrank) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, p2);
-//		if (p2<p1) accepted=1;
-//	}
-//  if (accepted==1) replicas_swap(conf_acc[rep_indx1],conf_acc[rep_indx2], rep_indx1, rep_indx2, hpt_params);
-//  return accepted;
-//}
 
 int metro_SWAP_worldmaster(double Delta_S_SWAP){
   double p1,randoub;
@@ -1180,64 +709,13 @@ int metro_SWAP_worldmaster(double Delta_S_SWAP){
 		if(debug_settings.do_norandom_test) randoub=0.0; // NORANDOM
 		else { // NORMAL, RANDOM
 			randoub=casuale();
-//#ifdef MULTIDEVICE
-//			MPI_Bcast((void*) &randoub,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
-//#endif
 		}
-//		if(verbosity_lv>8) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, randoub);
-		printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, randoub); //XXX: removeme
+		if(verbosity_lv>8) printf("p_metro = %.15lg, p_extracted= %.15lg\n", p1, randoub);
 		if (randoub<p1) accepted=1;
 	}
-//  if (accepted==1) replicas_swap(conf_acc[rep_indx1],conf_acc[rep_indx2], rep_indx1, rep_indx2, hpt_params);
   return accepted;
 }
 
-////TODO: reimplement without explicit swap, but at the label level in world root
-//void All_Conf_SWAP( su3_soa ** conf_acc,
-//										__restrict su3_soa * const loc_plaq,
-//										dcomplex_soa * const tr_local_plaqs, 
-//										defect_info * def, 
-//										int* swap_num,
-//										int * all_swap_vet,
-//										int * acceptance_vet, rep_info * hpt_params){
-//
-//  double swap_order;
-//  int replicas_number = hpt_params->replicas_total_number;
-//
-//  if(0==devinfo.myrank){swap_order=casuale();}
-//
-//#ifdef MULTIDEVICE
-//  MPI_Bcast((void*) &swap_order,1,MPI_DOUBLE,0,devinfo.mpi_comm);
-//#endif
-//
-//  int accepted=0;
-//  int i_counter, j_counter;
-//   
-//  if(swap_order<=0.5){
-//		if (0==devinfo.myrank) printf("Swap order: 0->N_r-1\n");
-//
-//		for(i_counter=0;i_counter<replicas_number-1;i_counter++){
-//      if(verbosity_lv>4 && 0==devinfo.myrank) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
-//      accepted=metro_SWAP(conf_acc, loc_plaq, tr_local_plaqs, i_counter, i_counter+1, def, hpt_params);
-//			#pragma acc update device(conf_acc[0:replicas_number][0:8])
-//      *swap_num=*swap_num+1;
-//      all_swap_vet[i_counter]++;
-//      if (accepted==1) acceptance_vet[i_counter]++;
-//    }
-//  }
-//  else{
-//		if (0==devinfo.myrank) printf("Swap order: N_r-1->0\n");
-//
-//    for(i_counter=0;i_counter<replicas_number-1;i_counter++){
-//      if(verbosity_lv>4 && 0==devinfo.myrank) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
-//      accepted=metro_SWAP( conf_acc,loc_plaq,tr_local_plaqs, replicas_number-i_counter-1, replicas_number-i_counter-2, def, hpt_params);
-//			#pragma acc update device(conf_acc[0:replicas_number][0:8])      
-//      *swap_num=*swap_num+1;
-//      all_swap_vet[replicas_number-i_counter-2]++;
-//      if(accepted==1) acceptance_vet[replicas_number-i_counter-2]++;
-//    }
-//  }
-//}
 
 void manage_replica_swaps(
                     su3_soa * tconf_acc,
@@ -1252,63 +730,60 @@ void manage_replica_swaps(
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    // select relabeling and scatter coefficients to
-    // each mpirank
-      double swap_order;
-      int replicas_number = NREPLICAS;//hpt_params->replicas_total_number;
+    // select relabeling and scatter coefficients to each mpirank
+    double swap_order;
+    int replicas_number = NREPLICAS;//hpt_params->replicas_total_number;
 
     if (0==devinfo.myrank_world){
       swap_order=casuale();
     }
     MPI_Bcast((void*)&swap_order,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
 
-      int accepted=0;
-      int i_counter, j_counter; // labels
-      int replicas_num_prev,replicas_num_next;
-      for(i_counter=0;i_counter<replicas_number-1;i_counter++){
+    int accepted=0;
+    int i_counter, j_counter; // indexes, not labels
+    int rep_lab1,rep_lab2;
+    for(i_counter=0;i_counter<replicas_number-1;i_counter++){
+      // manages each pairs serially in a chained fashion
 
-        for(int lab=0; lab<NREPLICAS; ++lab){
-          S_arr_prev[lab]=0.0;
-        }
-        compute_S_of_replicas(tconf_acc, loc_plaq, tr_local_plaqs, def, &S_arr_prev[0]);
+      for(int lab=0; lab<NREPLICAS; ++lab){
+        S_arr_prev[lab]=0.0;
+      }
+      compute_S_of_replicas(tconf_acc, loc_plaq, tr_local_plaqs, def, &S_arr_prev[0]);
 
-        if(devinfo.myrank_world==0){
-          for(int lab=0; lab<NREPLICAS; ++lab){
-            MPI_PRINTF1("i_counter: %d, S_arr_prev[%d]=%lg\n",i_counter, lab,S_arr_prev[lab]);
-          }
-        }
 
-        if(swap_order<=0.5){ 
-          MPI_PRINTF0("Swap order: 0->N_r-1\n"); //
-          replicas_num_prev=hpt_params->label[i_counter];
-          replicas_num_next=hpt_params->label[i_counter+1];
-        }else{
-          MPI_PRINTF0("Swap order: N_r-1->0\n");
-          replicas_num_prev=hpt_params->label[replicas_number-i_counter-1];
-          replicas_num_next=hpt_params->label[replicas_number-i_counter-2];
-        }
+      if(swap_order<=0.5){ 
+//        MPI_PRINTF0("Swap order: 0->N_r-1\n"); //
+        rep_lab1=hpt_params->label[i_counter];
+        rep_lab2=hpt_params->label[i_counter+1];
+      }else{
+//        MPI_PRINTF0("Swap order: N_r-1->0\n");
+        rep_lab1=hpt_params->label[replicas_number-i_counter-1];
+        rep_lab2=hpt_params->label[replicas_number-i_counter-2];
+      }
 
 //        if(verbosity_lv>4) printf("proposing swap %d %d\n",i_counter,i_counter+1);      
-        printf("proposing swap %d %d\n",replicas_num_prev,replicas_num_next);      
-        
-        //TODO: ensure that hpt_params->cr_vec is synced for all mpirank
-        //TODO: check whether one has to use a label filter for replicas somewhere
-        
-        // replicas_num_prev and replicas_num_next are tried for swap
-        if(replicas_num_prev==hpt_params->label[devinfo.replica_idx]){
-          // set defect as next
-          MPI_PRINTF1("replica lab: %d gets coefficient %lf\n",replicas_num_prev,hpt_params->cr_vec[replicas_num_next]);
-          init_k(tconf_acc,hpt_params->cr_vec[replicas_num_next],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
-        }
-        if(replicas_num_next==hpt_params->label[devinfo.replica_idx]){
-          // set defect as prev
-          MPI_PRINTF1("replica lab: %d gets coefficient %lf\n",replicas_num_next,hpt_params->cr_vec[replicas_num_prev]);
-          init_k(tconf_acc,hpt_params->cr_vec[replicas_num_prev],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
-        }
-        //TODO: possibly optimize by updating only defect info
-        #pragma acc update device(tconf_acc[0:alloc_info.conf_acc_size])
+      if(devinfo.myrank_world==0){
+//        for(int lab=0; lab<NREPLICAS; ++lab){
+//          MPI_PRINTF1("i_counter: %d, S_arr_prev[%d]=%lg\n",i_counter, lab,S_arr_prev[lab]);
+//        }
+        printf("proposing swap %d %d\n",rep_lab1,rep_lab2);      
+      }
+      
+      // rep_lab1 and rep_lab2 are tried for swap
+      if(rep_lab1==hpt_params->label[devinfo.replica_idx]){
+        // set defect as next
+        MPI_PRINTF1("replica lab: %d gets coefficient %lf\n",rep_lab1,hpt_params->cr_vec[rep_lab2]);
+        init_k(tconf_acc,hpt_params->cr_vec[rep_lab2],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+      }
+      if(rep_lab2==hpt_params->label[devinfo.replica_idx]){
+        // set defect as prev
+        MPI_PRINTF1("replica lab: %d gets coefficient %lf\n",rep_lab2,hpt_params->cr_vec[rep_lab1]);
+        init_k(tconf_acc,hpt_params->cr_vec[rep_lab1],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+      }
+      //TODO: possibly optimize by updating only defect info
+      #pragma acc update device(tconf_acc[0:alloc_info.conf_acc_size])
 
-        MPI_Barrier(MPI_COMM_WORLD);
+      MPI_Barrier(MPI_COMM_WORLD);
 
       for(int lab=0; lab<NREPLICAS; ++lab){
         S_arr_next[lab]=0.0;
@@ -1316,94 +791,90 @@ void manage_replica_swaps(
       compute_S_of_replicas(tconf_acc, loc_plaq, tr_local_plaqs, def, &S_arr_next[0]);
 
       if(devinfo.myrank_world==0){
-        for(int lab=0; lab<NREPLICAS; ++lab){
-          MPI_PRINTF1("icounter: %d, S_arr_next[%d]=%lg\n",i_counter, lab,S_arr_next[lab]);
-        }
+//        for(int lab=0; lab<NREPLICAS; ++lab){
+//          MPI_PRINTF1("icounter: %d, S_arr_next[%d]=%lg\n",i_counter, lab,S_arr_next[lab]);
+//        }
 
-        MPI_PRINTF1("All actions next[prev], next[next], prev[prev], prev[next]: %lf, %lf, %lf, %lf\n",
-            S_arr_next[replicas_num_prev], S_arr_next[replicas_num_next], 
-            S_arr_prev[replicas_num_prev], S_arr_prev[replicas_num_next])
+        MPI_PRINTF1("All actions S_next1, S_next2, S_prev1, S_prev2: %lf, %lf, %lf, %lf\n",
+            S_arr_next[rep_lab1], S_arr_next[rep_lab2], 
+            S_arr_prev[rep_lab1], S_arr_prev[rep_lab2])
       }
 //      // All mpiranks access this  
 //      int do_perform_swap=1;
 
       if (0==devinfo.myrank_world){
         // compute acceptance:
-        double Delta_S_SWAP =  S_arr_next[replicas_num_prev]
-                              +S_arr_next[replicas_num_next]
-                              -S_arr_prev[replicas_num_prev]
-                              -S_arr_prev[replicas_num_next];
+        double Delta_S_SWAP =  S_arr_next[rep_lab1]
+                              +S_arr_next[rep_lab2]
+                              -S_arr_prev[rep_lab1]
+                              -S_arr_prev[rep_lab2];
         accepted=metro_SWAP_worldmaster(Delta_S_SWAP);
-        printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n", replicas_num_prev, replicas_num_next, Delta_S_SWAP);
+        printf("DELTA_S_SWAP(lab1=%d,lab2=%d):%.15lg\n", rep_lab1, rep_lab2, Delta_S_SWAP);
         //if(verbosity_lv>8) printf("DELTA_S_SWAP(r1=%d,r2=%d):%.15lg\n",
 
         if(accepted){
+          // search which indexes are associated the swapped labels
           int aux_label;
-          int ii,jj;
-          //TODO: possibly optimize with an inverse label map
-          for(int idx=0; idx<hpt_params->replicas_total_number; ++idx){
-            if(hpt_params->label[idx]==replicas_num_prev){
+          int ii,jj; // indexes
+          //TODO: maybe optimize with an inverse label map
+          for(int idx=0; idx<replicas_number; ++idx){
+            if(hpt_params->label[idx]==rep_lab1){
               ii=idx;
-            }else if(hpt_params->label[idx]==replicas_num_next){
+            }else if(hpt_params->label[idx]==rep_lab2){
               jj=idx;
             }
           }
-          MPI_PRINTF1("Swapping between %d and %d accepted\n",replicas_num_prev,replicas_num_next);
+          MPI_PRINTF1("Swap between %d and %d accepted\n",rep_lab1,rep_lab2);
           aux_label=hpt_params->label[ii];
           hpt_params->label[ii] = hpt_params->label[jj];
           hpt_params->label[jj] = aux_label;
         }
       }
 
-      //TODO: maybe remove it since superfluous
       MPI_Bcast((void*)&(hpt_params->label[0]),NREPLICAS,MPI_INT,0,MPI_COMM_WORLD);
-      MPI_Bcast((void*)&accepted,1,MPI_INT,0,MPI_COMM_WORLD);
-//      MPI_Bcast((void*)&hpt_params->cr_vec[0],NREPLICAS,MPI_DOUBLE,0,MPI_COMM_WORLD);
+      MPI_Bcast((void*)&accepted,1,MPI_INT,0,MPI_COMM_WORLD); // each replica must know if pairs are swapped
 
-      if(!accepted && replicas_num_prev==hpt_params->label[devinfo.replica_idx]){
+      // if swap not accepted, the involved replicas must update their defect information 
+      // back to their previous state (prev with prev and next with next)
+      if(!accepted && rep_lab1==hpt_params->label[devinfo.replica_idx]){
         // set defect as next
-        init_k(tconf_acc,hpt_params->cr_vec[replicas_num_prev],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+        init_k(tconf_acc,hpt_params->cr_vec[rep_lab1],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
       }
-      if(!accepted && replicas_num_next==hpt_params->label[devinfo.replica_idx]){
+      if(!accepted && rep_lab2==hpt_params->label[devinfo.replica_idx]){
         // set defect as prev
-        init_k(tconf_acc,hpt_params->cr_vec[replicas_num_next],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
+        init_k(tconf_acc,hpt_params->cr_vec[rep_lab2],hpt_params->defect_boundary,hpt_params->defect_coordinates,&def,1);
       }
       //TODO: possibly optimize by updating only defect info
       #pragma acc update device(tconf_acc[0:alloc_info.conf_acc_size])
 
-
-      //XXX: debug!
-      for(int idx=0; idx<rep->replicas_total_number; ++idx){
-        MPI_PRINTF1("labels: label[%d]=%d\n",idx,hpt_params->label[idx]);
-      }
-      MPI_PRINTF1("before swapupdate: swap_num    =%d\n",*swap_num);
-      for(int labp=0; labp<rep->replicas_total_number; ++labp){
-        MPI_PRINTF1("labels: label[%d]=%d\n",labp,hpt_params->label[labp]);
-        MPI_PRINTF1("before swapupdate: all_swap_vet[%d]  =%d (prev: %d, next %d)\n",labp,all_swap_vet[labp],replicas_num_prev ,  replicas_num_next);
-        if(labp<rep->replicas_total_number-1){
-          MPI_PRINTF1("before swapupdate: acceptance_vet[%d]=%d (prev: %d, next %d)\n",labp,acceptance_vet[labp],replicas_num_prev ,  replicas_num_next);
-        }
-      }
+//      //XXX: debug!
+//      for(int idx=0; idx<rep->replicas_total_number; ++idx){
+//        MPI_PRINTF1("labels: label[%d]=%d\n",idx,hpt_params->label[idx]);
+//      }
+//      MPI_PRINTF1("before swapupdate: swap_num    =%d\n",*swap_num);
+//      for(int labp=0; labp<rep->replicas_total_number; ++labp){
+//        MPI_PRINTF1("labels: label[%d]=%d\n",labp,hpt_params->label[labp]);
+//        MPI_PRINTF1("before swapupdate: all_swap_vet[%d]  =%d (prev: %d, next %d)\n",labp,all_swap_vet[labp],rep_lab1 ,  rep_lab2);
+//        if(labp<rep->replicas_total_number-1){
+//          MPI_PRINTF1("before swapupdate: acceptance_vet[%d]=%d (prev: %d, next %d)\n",labp,acceptance_vet[labp],rep_lab1 ,  rep_lab2);
+//        }
+//      }
 
       *swap_num=*swap_num+1;
-      int replicas_num_fixed = (swap_order<=0.5)? replicas_num_prev :  replicas_num_next;
+      int replicas_num_fixed = (swap_order<=0.5)? rep_lab1 :  rep_lab2;
       all_swap_vet[replicas_num_fixed]++;
       if(accepted==1) acceptance_vet[replicas_num_fixed]++;
-//      MPI_Bcast((void*)&(all_swap_vet),NREPLICAS,MPI_INT,0,MPI_COMM_WORLD);
+      //TODO: these arrays are managed by world master only, they could be deallocated for others
 
-      //XXX: debug!
-      MPI_PRINTF1("after  swapupdate: swap_num    =%d\n",*swap_num);
-      for(int labp=0; labp<rep->replicas_total_number; ++labp){
-        MPI_PRINTF1("after  swapupdate: all_swap_vet[%d]  =%d (prev: %d, next %d)\n",labp,all_swap_vet[labp],replicas_num_prev ,  replicas_num_next);
-        MPI_PRINTF1("after  swapupdate: acceptance_vet[%d]=%d (prev: %d, next %d)\n",labp,acceptance_vet[labp],replicas_num_prev ,  replicas_num_next);
-      }
+//      //XXX: debug!
+//      MPI_PRINTF1("after  swapupdate: swap_num    =%d\n",*swap_num);
+//      for(int labp=0; labp<rep->replicas_total_number; ++labp){
+//        MPI_PRINTF1("after  swapupdate: all_swap_vet[%d]  =%d (prev: %d, next %d)\n",labp,all_swap_vet[labp],rep_lab1 ,  rep_lab2);
+//        MPI_PRINTF1("after  swapupdate: acceptance_vet[%d]=%d (prev: %d, next %d)\n",labp,acceptance_vet[labp],rep_lab1 ,  rep_lab2);
+//      }
 
       MPI_Barrier(MPI_COMM_WORLD); 
     }
-
-    // receive scattered info
-
-    MPI_Barrier(MPI_COMM_WORLD);
 }
 
     

--- a/src/OpenAcc/HPT_utilities.h
+++ b/src/OpenAcc/HPT_utilities.h
@@ -35,43 +35,71 @@ typedef struct defect_info_t{
 extern defect_info *def;
 
 void counter_size_function(int d0,int d1,int d2,int d3);
-void init_k(su3_soa * conf,double c_r,int def_axis,int * def_vec,defect_info * def,int defect_info_config);
+void init_k(su3_soa * conf,double c_r,int def_axis,int * def_vec,defect_info * def, int defect_info_config);
 void printing_k_mu(su3_soa * conf);
 void trasl_conf( __restrict const su3_soa *  const tconf_acc,
                  __restrict const su3_soa *  const taux_conf);
 
-void replicas_swap(su3_soa * conf1,su3_soa * conf2, int lab1, int lab2, rep_info * hpt_params);
+//void replicas_swap(su3_soa * conf1,su3_soa * conf2, int lab1, int lab2, rep_info * hpt_params);
 void label_print(rep_info * hpt_params, FILE *file, int step_number);
 
+//#ifdef GAUGE_ACT_TLSM
+//double calc_Delta_S_Symanzik_SWAP( __restrict const su3_soa * const u,
+//                                   __restrict const su3_soa * const w,
+//                                   __restrict su3_soa * const loc_rects,
+//                                   dcomplex_soa * const tr_local_rects,
+//                                   const int mu, const int nu, defect_info * def);
+//#endif //GAUGE_ACT_TLSM
+
 #ifdef GAUGE_ACT_TLSM
-double calc_Delta_S_Symanzik_SWAP( __restrict const su3_soa * const u,
-                                   __restrict const su3_soa * const w,
-                                   __restrict su3_soa * const loc_rects,
-                                   dcomplex_soa * const tr_local_rects,
-                                   const int mu, const int nu, defect_info * def);
-#endif
+double calc_S_Symanzik_defect(__restrict const su3_soa * const u,
+                              __restrict su3_soa * const loc_rects,
+                              dcomplex_soa * const tr_local_rects,
+                              const int mu, const int nu, defect_info * def);
+#endif //GAUGE_ACT_TLSM
 
-double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
-                                __restrict const su3_soa * const w,
-                                __restrict su3_soa * const loc_plaq,
-                                dcomplex_soa * const tr_local_plaqs, 
-                                const int mu, const int nu, defect_info * def);
+//double calc_Delta_S_Wilson_SWAP(__restrict const su3_soa * const u,
+//                                __restrict const su3_soa * const w,
+//                                __restrict su3_soa * const loc_plaq,
+//                                dcomplex_soa * const tr_local_plaqs, 
+//                                const int mu, const int nu, defect_info * def);
 
-double calc_Delta_S_soloopenacc_SWAP( __restrict  su3_soa * const tconf_acc,
-																			__restrict  su3_soa * const tconf_acc2,
-																			__restrict su3_soa * const local_plaqs,
-																			dcomplex_soa * const tr_local_plaqs,defect_info * def);
+double calc_S_Wilson_defect(__restrict const su3_soa * const u,
+                              __restrict su3_soa * const loc_plaq,
+                              dcomplex_soa * const tr_local_plaqs,
+                              const int mu, const int nu, defect_info * def);
 
-int metro_SWAP(su3_soa ** conf_acc,
-               __restrict su3_soa * const loc_plaq,
-               dcomplex_soa * const tr_local_plaqs,
-               int rep_indx1, int rep_indx2,defect_info * def, rep_info *hpt_params);
 
-void All_Conf_SWAP(su3_soa ** conf_acc,
-                   __restrict su3_soa * const loc_plaq,
-                   dcomplex_soa * const tr_local_plaqs,                   
-                   defect_info * def, 
-									 int *swap_num,int * all_swap_vet, int * acceptance_vet, rep_info *hpt_params);
+//double calc_Delta_S_soloopenacc_SWAP( __restrict  su3_soa * const tconf_acc,
+//																			__restrict  su3_soa * const tconf_acc2,
+//																			__restrict su3_soa * const local_plaqs,
+//																			dcomplex_soa * const tr_local_plaqs,defect_info * def);
 
-#endif
-#endif
+double calc_S_soloopenacc_defect(__restrict  su3_soa * const tconf_acc,
+																 __restrict su3_soa * const local_plaqs,
+																 dcomplex_soa * const tr_local_plaqs,defect_info * def);
+
+
+//int metro_SWAP(su3_soa ** conf_acc,
+//               __restrict su3_soa * const loc_plaq,
+//               dcomplex_soa * const tr_local_plaqs,
+//               int rep_indx1, int rep_indx2,defect_info * def, rep_info *hpt_params);
+
+int metro_SWAP_worldmaster(double Delta_S_SWAP);
+
+
+//void All_Conf_SWAP(su3_soa ** conf_acc,
+//                   __restrict su3_soa * const loc_plaq,
+//                   dcomplex_soa * const tr_local_plaqs,                   
+//                   defect_info * def, 
+//									 int *swap_num,int * all_swap_vet, int * acceptance_vet, rep_info *hpt_params);
+void compute_S_of_replicas(
+                        __restrict su3_soa * const tconf_acc, 
+                        __restrict su3_soa * const local_plaq, 
+                        dcomplex_soa * const tr_local_plaqs,
+                        defect_info * def,
+                        double * S_arr);
+
+
+#endif // PAR_TEMP
+#endif // HPT_UTILITIES_H

--- a/src/OpenAcc/alloc_vars.c
+++ b/src/OpenAcc/alloc_vars.c
@@ -124,7 +124,7 @@ void mem_alloc_core(){
 
     
 	alloc_info.conf_acc_size = 8;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 	if(devinfo.async_comm_gauge) alloc_info.conf_acc_size *=2 ; 
 #endif
 

--- a/src/OpenAcc/alloc_vars.c
+++ b/src/OpenAcc/alloc_vars.c
@@ -124,7 +124,7 @@ void mem_alloc_core(){
 
     
 	alloc_info.conf_acc_size = 8;
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.async_comm_gauge) alloc_info.conf_acc_size *=2 ; 
 #endif
 

--- a/src/OpenAcc/alloc_vars.c
+++ b/src/OpenAcc/alloc_vars.c
@@ -57,7 +57,7 @@ tamat_soa * ipdot_f_old; // for HMC diagnostics
 su3_soa * gconf_as_fermionmatrix; // (only a pointer) conf to use in either cases 
                                   // in fermion related computation (with or without stouting)
 
-su3_soa ** conf_acc; // gauge configuration(s)
+su3_soa * conf_acc; // gauge configuration(s)
 
 // STOUTING UTILITIES
 su3_soa * gstout_conf_acc_arr; // all stouting steps except the zeroth
@@ -128,15 +128,19 @@ void mem_alloc_core(){
 	if(devinfo.async_comm_gauge) alloc_info.conf_acc_size *=2 ; 
 #endif
 
-	allocation_check =  POSIX_MEMALIGN_WRAPPER((void **)&conf_acc, ALIGN,
-																						 alloc_info.num_replicas*sizeof(su3_soa*));
+//	allocation_check =  POSIX_MEMALIGN_WRAPPER((void **)&conf_acc, ALIGN,
+//																						 alloc_info.num_replicas*sizeof(su3_soa*));
+	allocation_check =  POSIX_MEMALIGN_WRAPPER((void *)&conf_acc, ALIGN, sizeof(su3_soa*));
 
-	for(int r=0; r<alloc_info.num_replicas; r++){
-		POSIX_MEMALIGN_WRAPPER((void **)&conf_acc[r], ALIGN,
-													 alloc_info.conf_acc_size*sizeof(su3_soa));
-		ALLOCCHECK(allocation_check, conf_acc[r]);
-	}
-	#pragma acc enter data create(conf_acc[0:alloc_info.num_replicas][0:alloc_info.conf_acc_size])
+//	for(int r=0; r<alloc_info.num_replicas; r++){
+//		POSIX_MEMALIGN_WRAPPER((void **)&conf_acc[r], ALIGN,
+//													 alloc_info.conf_acc_size*sizeof(su3_soa));
+//		ALLOCCHECK(allocation_check, conf_acc[r]);
+//	}
+//	#pragma acc enter data create(conf_acc[0:alloc_info.num_replicas][0:alloc_info.conf_acc_size])
+		POSIX_MEMALIGN_WRAPPER((void *)&conf_acc, ALIGN, alloc_info.conf_acc_size*sizeof(su3_soa));
+		ALLOCCHECK(allocation_check, conf_acc);
+	#pragma acc enter data create(conf_acc[0:alloc_info.conf_acc_size])
 }
 
 void mem_alloc_extended()
@@ -326,10 +330,10 @@ void mem_free_core()
 	FREECHECK(u1_back_phases);        
 	#pragma acc exit data delete(u1_back_phases)        
 
-	for(int r=0;r<alloc_info.num_replicas;r++){
-		FREECHECK(conf_acc[r]);
-	}
-	#pragma acc exit data delete(conf_acc[0:alloc_info.num_replicas][0:alloc_info.conf_acc_size])
+//	for(int r=0;r<alloc_info.num_replicas;r++){
+//		FREECHECK(conf_acc[r]);
+//	}
+//	#pragma acc exit data delete(conf_acc[0:alloc_info.num_replicas][0:alloc_info.conf_acc_size])
 
 	FREECHECK(conf_acc);
 	#pragma acc exit data delete(conf_acc)

--- a/src/OpenAcc/alloc_vars.h
+++ b/src/OpenAcc/alloc_vars.h
@@ -47,7 +47,7 @@ extern tamat_soa * ipdot_f_old; // for HMC diagnostics
 extern su3_soa * gconf_as_fermionmatrix; // (only a pointer) conf to use in either cases 
                                          // in fermion related computation (with or without stouting)
 
-extern su3_soa ** conf_acc; // gauge configuration(s)
+extern su3_soa * conf_acc; // gauge configuration(s)
 
 // STOUTING 
 extern su3_soa * gstout_conf_acc_arr; // all stouting steps except the zeroth

--- a/src/OpenAcc/backfield.c
+++ b/src/OpenAcc/backfield.c
@@ -43,11 +43,12 @@ void calc_u1_phases_unb_no2pi(double_soa * phases,bf_param bf_pars,
 
 	}
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 
-	printf("MPI%02d: Origin coordinates: (x=%02d y=%02d z=%02d t=%02d)\n",
-				 devinfo.myrank ,  devinfo.origin_0123[geom_par.xmap],
-				 devinfo.origin_0123[geom_par.ymap], devinfo.origin_0123[geom_par.zmap],
+	MPI_PRINTF1("Origin coordinates: (x=%02d y=%02d z=%02d t=%02d)\n",
+         devinfo.origin_0123[geom_par.xmap],
+				 devinfo.origin_0123[geom_par.ymap], 
+         devinfo.origin_0123[geom_par.zmap],
 				 devinfo.origin_0123[geom_par.tmap]);
 
 
@@ -70,7 +71,7 @@ void calc_u1_phases_unb_no2pi(double_soa * phases,bf_param bf_pars,
 																				z = d[geom_par.zmap];int tnz = geom_par.gnz;
 																				t = d[geom_par.tmap];int tnt = geom_par.gnt;
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 																				x+= devinfo.origin_0123[geom_par.xmap]
 																					- devinfo.halo_widths0123[geom_par.xmap];  
 																				y+= devinfo.origin_0123[geom_par.ymap]

--- a/src/OpenAcc/backfield.c
+++ b/src/OpenAcc/backfield.c
@@ -43,7 +43,7 @@ void calc_u1_phases_unb_no2pi(double_soa * phases,bf_param bf_pars,
 
 	}
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 
 	printf("MPI%02d: Origin coordinates: (x=%02d y=%02d z=%02d t=%02d)\n",
 				 devinfo.myrank ,  devinfo.origin_0123[geom_par.xmap],
@@ -70,7 +70,7 @@ void calc_u1_phases_unb_no2pi(double_soa * phases,bf_param bf_pars,
 																				z = d[geom_par.zmap];int tnz = geom_par.gnz;
 																				t = d[geom_par.tmap];int tnt = geom_par.gnt;
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 																				x+= devinfo.origin_0123[geom_par.xmap]
 																					- devinfo.halo_widths0123[geom_par.xmap];  
 																				y+= devinfo.origin_0123[geom_par.ymap]

--- a/src/OpenAcc/cooling.c
+++ b/src/OpenAcc/cooling.c
@@ -174,27 +174,27 @@ void cool_conf(__restrict su3_soa   * const U, // unsmeared input conf
 							 __restrict su3_soa   * const TMP){ // auxiliary staple container
 
   set_su3_soa_to_zero(TMP);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
   communicate_su3_borders(U, GAUGE_HALO);  
 #endif
  
   calc_loc_staples_nnptrick_all_only_even(U,TMP);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
   communicate_gl3_borders(TMP, GAUGE_HALO);  
 #endif
 
   compute_cooled_even_links(U,Ucool,TMP);
   calc_loc_staples_nnptrick_all_only_odd(U,TMP);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
   communicate_gl3_borders(TMP, GAUGE_HALO);  
 #endif  
 
   compute_cooled_odd_links(U,Ucool,TMP);
   unitarize_conf(Ucool);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
   communicate_su3_borders(Ucool, GAUGE_HALO);  
 #endif
 

--- a/src/OpenAcc/cooling.c
+++ b/src/OpenAcc/cooling.c
@@ -174,27 +174,27 @@ void cool_conf(__restrict su3_soa   * const U, // unsmeared input conf
 							 __restrict su3_soa   * const TMP){ // auxiliary staple container
 
   set_su3_soa_to_zero(TMP);
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
   communicate_su3_borders(U, GAUGE_HALO);  
 #endif
  
   calc_loc_staples_nnptrick_all_only_even(U,TMP);
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
   communicate_gl3_borders(TMP, GAUGE_HALO);  
 #endif
 
   compute_cooled_even_links(U,Ucool,TMP);
   calc_loc_staples_nnptrick_all_only_odd(U,TMP);
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
   communicate_gl3_borders(TMP, GAUGE_HALO);  
 #endif  
 
   compute_cooled_odd_links(U,Ucool,TMP);
   unitarize_conf(Ucool);
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
   communicate_su3_borders(Ucool, GAUGE_HALO);  
 #endif
 

--- a/src/OpenAcc/deviceinit.c
+++ b/src/OpenAcc/deviceinit.c
@@ -19,13 +19,13 @@ void select_init_acc_device(acc_device_t my_device_type, int dev_index)
 
   // get available devices of this type
   int num_devices = acc_get_num_devices(my_device_type);
-  printf("MPI%02d: Number of OpenAcc exploitable devices found: %d \n",
-				 devinfo.myrank, num_devices);
+  printf("MPI%02d:%02d: Number of OpenAcc exploitable devices found: %d \n", 
+      devinfo.replica_idx, devinfo.myrank, num_devices);
 
   // pick the device number dev_index 
   acc_set_device_num(dev_index, my_device_type);
-  printf("MPI%02d: Selected device number: %d \n",
-				 devinfo.myrank, dev_index);
+  printf("MPI%02d:%02d: Selected device number: %d \n", 
+      devinfo.replica_idx, devinfo.myrank, dev_index);
 
 }
 

--- a/src/OpenAcc/fermion_force.c
+++ b/src/OpenAcc/fermion_force.c
@@ -212,7 +212,6 @@ void fermion_force_soloopenacc(__restrict su3_soa    * tconf_acc,
 		if(0==devinfo.myrank && verbosity_lv >2) 
 			printf("Converting gauge conf to single precision...\n");
 		conf_to_use_f = conf_acc_f; // using global variable for convenience.
-		// ^^^ WARNING: this works only for sequential replicas updating. If you want to parallelize it, use conf_acc_f[replica_id].
 		convert_double_to_float_su3_soa(conf_to_use,conf_to_use_f);
 		ipt.u_f = conf_to_use_f;
 	}

--- a/src/OpenAcc/fermion_force.c
+++ b/src/OpenAcc/fermion_force.c
@@ -96,12 +96,12 @@ void compute_sigma_from_sigma_prime_backinto_sigma_prime(  __restrict su3_soa   
 	calc_loc_staples_nnptrick_all_onlyferms(U,TMP);
 	if(verbosity_lv > 4)printf("MPI%02d:\t\tcomputed staples  \n",
 														 devinfo.myrank);
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_gl3_borders(TMP,1);
 #endif
 	RHO_times_conf_times_staples_ta_part(U,TMP,QA,istopo);
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_tamat_soa_borders(QA,1);
 #endif
 
@@ -119,7 +119,7 @@ void compute_sigma_from_sigma_prime_backinto_sigma_prime(  __restrict su3_soa   
 	}
 	compute_lambda(Lambda,Sigma,U,QA,TMP);
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_thmat_soa_borders(Lambda,1);
 #endif
 
@@ -155,7 +155,7 @@ void compute_sigma_from_sigma_prime_backinto_sigma_prime(  __restrict su3_soa   
 
 
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_gl3_borders(Sigma,1);
 #endif
 

--- a/src/OpenAcc/fermion_force.c
+++ b/src/OpenAcc/fermion_force.c
@@ -211,7 +211,7 @@ void fermion_force_soloopenacc(__restrict su3_soa    * tconf_acc,
 		 1 == md_parameters.recycleInvsForce){
 		if(0==devinfo.myrank && verbosity_lv >2) 
 			printf("Converting gauge conf to single precision...\n");
-		conf_to_use_f = conf_acc_f[0]; // using global variable for convenience.
+		conf_to_use_f = conf_acc_f; // using global variable for convenience.
 		// ^^^ WARNING: this works only for sequential replicas updating. If you want to parallelize it, use conf_acc_f[replica_id].
 		convert_double_to_float_su3_soa(conf_to_use,conf_to_use_f);
 		ipt.u_f = conf_to_use_f;

--- a/src/OpenAcc/fermion_force.c
+++ b/src/OpenAcc/fermion_force.c
@@ -96,12 +96,12 @@ void compute_sigma_from_sigma_prime_backinto_sigma_prime(  __restrict su3_soa   
 	calc_loc_staples_nnptrick_all_onlyferms(U,TMP);
 	if(verbosity_lv > 4)printf("MPI%02d:\t\tcomputed staples  \n",
 														 devinfo.myrank);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_gl3_borders(TMP,1);
 #endif
 	RHO_times_conf_times_staples_ta_part(U,TMP,QA,istopo);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_tamat_soa_borders(QA,1);
 #endif
 
@@ -119,7 +119,7 @@ void compute_sigma_from_sigma_prime_backinto_sigma_prime(  __restrict su3_soa   
 	}
 	compute_lambda(Lambda,Sigma,U,QA,TMP);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_thmat_soa_borders(Lambda,1);
 #endif
 
@@ -155,7 +155,7 @@ void compute_sigma_from_sigma_prime_backinto_sigma_prime(  __restrict su3_soa   
 
 
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_gl3_borders(Sigma,1);
 #endif
 

--- a/src/OpenAcc/fermion_matrix.c
+++ b/src/OpenAcc/fermion_matrix.c
@@ -203,7 +203,7 @@ void acc_Deo(__restrict const su3_soa * const u,
 
 		}
 	}
-	//    MPI_Barrier(MPI_COMM_WORLD);
+	//    MPI_Barrier(devinfo.mpi_comm);
 #else 
 	acc_Deo_unsafe(u, out, in, backfield);
 #endif
@@ -259,7 +259,7 @@ void acc_Doe(__restrict const su3_soa * const u,
 
 		}
 	}
-	//    MPI_Barrier(MPI_COMM_WORLD);
+	//    MPI_Barrier(devinfo.mpi_comm);
 #else 
 	acc_Doe_unsafe(u, out, in, backfield);
 #endif

--- a/src/OpenAcc/fermion_matrix.c
+++ b/src/OpenAcc/fermion_matrix.c
@@ -160,7 +160,7 @@ void acc_Deo(__restrict const su3_soa * const u,
 						 __restrict const vec3_soa * const in,
 						 __restrict const double_soa * const backfield)
 {
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	if(devinfo.async_comm_fermion){
 
 #if defined(USE_MPI_CUDA_AWARE) || defined(__GNUC__)
@@ -215,7 +215,7 @@ void acc_Doe(__restrict const su3_soa * const u,
 						 __restrict const vec3_soa * const in,
 						 __restrict const double_soa * const backfield)
 {
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	if(devinfo.async_comm_fermion){
 
 #if defined(USE_MPI_CUDA_AWARE) || defined(__GNUC__)

--- a/src/OpenAcc/fermion_matrix.c
+++ b/src/OpenAcc/fermion_matrix.c
@@ -16,6 +16,7 @@
 #include "./matvecmul.h"
 #include "../tests_and_benchmarks/test_and_benchmarks.h"
 
+//TODO: check if this can be changed to NRANKS_D3 > 1
 #ifdef MULTIDEVICE
 #include "../Mpi/communications.h"
 #endif 
@@ -160,7 +161,7 @@ void acc_Deo(__restrict const su3_soa * const u,
 						 __restrict const vec3_soa * const in,
 						 __restrict const double_soa * const backfield)
 {
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.async_comm_fermion){
 
 #if defined(USE_MPI_CUDA_AWARE) || defined(__GNUC__)
@@ -215,7 +216,7 @@ void acc_Doe(__restrict const su3_soa * const u,
 						 __restrict const vec3_soa * const in,
 						 __restrict const double_soa * const backfield)
 {
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.async_comm_fermion){
 
 #if defined(USE_MPI_CUDA_AWARE) || defined(__GNUC__)

--- a/src/OpenAcc/fermionic_utilities.c
+++ b/src/OpenAcc/fermionic_utilities.c
@@ -25,7 +25,7 @@
 
 #include <stdlib.h>
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 #include <mpi.h>
 #include "../Mpi/multidev.h"
 

--- a/src/OpenAcc/fermionic_utilities.c
+++ b/src/OpenAcc/fermionic_utilities.c
@@ -94,8 +94,8 @@ d_complex scal_prod_global(const __restrict vec3_soa * const in_vect1,
 	double lri = cimag(local_res);
 	double trr,tri;
 
-	MPI_Allreduce((void*)&lrr,(void*)&trr,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
-	MPI_Allreduce((void*)&lri,(void*)&tri,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+	MPI_Allreduce((void*)&lrr,(void*)&trr,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
+	MPI_Allreduce((void*)&lri,(void*)&tri,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 
 	return trr + tri * I;
 }
@@ -106,7 +106,7 @@ double real_scal_prod_global(const __restrict vec3_soa * const in_vect1,
 	double total_res,local_res;
 	// local_res = real_scal_prod_loc(in_vect1,in_vect2); 
 	local_res = real_scal_prod_loc_1Dcut(in_vect1,in_vect2); 
-	MPI_Allreduce((void*)&local_res,(void*)&total_res,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+	MPI_Allreduce((void*)&local_res,(void*)&total_res,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 	return total_res;
 }
 double l2norm2_global(const __restrict vec3_soa * const in_vect1)
@@ -115,7 +115,7 @@ double l2norm2_global(const __restrict vec3_soa * const in_vect1)
 	double total_res,local_res;
 	// local_res = l2norm2_loc(in_vect1); 
 	local_res = l2norm2_loc_1Dcut(in_vect1); 
-	MPI_Allreduce((void*)&local_res,(void*)&total_res,1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+	MPI_Allreduce((void*)&local_res,(void*)&total_res,1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 	return total_res;
 }
 

--- a/src/OpenAcc/fermionic_utilities.c
+++ b/src/OpenAcc/fermionic_utilities.c
@@ -25,7 +25,7 @@
 
 #include <stdlib.h>
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 #include <mpi.h>
 #include "../Mpi/multidev.h"
 
@@ -120,7 +120,7 @@ double l2norm2_global(const __restrict vec3_soa * const in_vect1)
 }
 
 
-#else // no MULTIDEVICE
+#else // no NRANKS_D3 > 1
 
 
 d_complex scal_prod_global(const __restrict vec3_soa * in_vect1,
@@ -174,7 +174,7 @@ double l2norm2_global( __restrict  const vec3_soa * in_vect1 )
 	return resR;
 }
 
-#endif
+#endif // NRANKS_D3 > 1
 
 // starting from here, only "embarassingly parallel" functions, not requiring any reduction.
 void combine_in1xfactor_plus_in2(__restrict const vec3_soa * in_vect1,

--- a/src/OpenAcc/field_times_fermion_matrix.c
+++ b/src/OpenAcc/field_times_fermion_matrix.c
@@ -206,7 +206,7 @@ void acc_Deo_wf( __restrict const su3_soa * const u,
 								 __restrict const double_soa* field_im)   // or i dphi/dbz 
 {
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	acc_Deo_wf_unsafe(u, out, in, phases, field_re,field_im);
 	communicate_fermion_borders(out); // contains host-device communications
 #else 
@@ -224,7 +224,7 @@ void acc_Doe_wf( __restrict const su3_soa * const u,
 								 __restrict const double_soa* field_im)   // or i dphi/dbz 
 {
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	acc_Doe_wf_unsafe(u, out, in, phases,field_re,field_im);
 	communicate_fermion_borders(out); // contains host-device communications
 #else 

--- a/src/OpenAcc/field_times_fermion_matrix.c
+++ b/src/OpenAcc/field_times_fermion_matrix.c
@@ -206,7 +206,7 @@ void acc_Deo_wf( __restrict const su3_soa * const u,
 								 __restrict const double_soa* field_im)   // or i dphi/dbz 
 {
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	acc_Deo_wf_unsafe(u, out, in, phases, field_re,field_im);
 	communicate_fermion_borders(out); // contains host-device communications
 #else 
@@ -224,7 +224,7 @@ void acc_Doe_wf( __restrict const su3_soa * const u,
 								 __restrict const double_soa* field_im)   // or i dphi/dbz 
 {
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	acc_Doe_wf_unsafe(u, out, in, phases,field_re,field_im);
 	communicate_fermion_borders(out); // contains host-device communications
 #else 

--- a/src/OpenAcc/io.c
+++ b/src/OpenAcc/io.c
@@ -592,7 +592,7 @@ void rw_iterate_on_global_sites_lx_xyzt_axis_ordering(void (*single_element_rw)(
 																						else {
 																							x = xtmp;
 																							parity = (x+y+z+t)%2; // parity = (d0+d1+d2+d3)%2;
-#if defined(MULTIDEVICE) && defined(GAUGE_ACT_WILSON)
+#if (NRANKS_D3 > 1) && defined(GAUGE_ACT_WILSON)
 																							parity = !parity;
 #endif
 																						}
@@ -600,7 +600,7 @@ void rw_iterate_on_global_sites_lx_xyzt_axis_ordering(void (*single_element_rw)(
 																						int d[4];
 																						for(dir = 0; dir<4;dir++) d[dir] = xs[geom_par.d0123map[dir]];
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 																						int idxh_machine = gl_to_gl_snum(d[0],d[1],d[2],d[3]);
 #else
 																						int idxh_machine = snum_acc(d[0],d[1],d[2],d[3]);

--- a/src/OpenAcc/io.c
+++ b/src/OpenAcc/io.c
@@ -600,7 +600,7 @@ void rw_iterate_on_global_sites_lx_xyzt_axis_ordering(void (*single_element_rw)(
 																						int d[4];
 																						for(dir = 0; dir<4;dir++) d[dir] = xs[geom_par.d0123map[dir]];
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 																						int idxh_machine = gl_to_gl_snum(d[0],d[1],d[2],d[3]);
 #else
 																						int idxh_machine = snum_acc(d[0],d[1],d[2],d[3]);

--- a/src/OpenAcc/io.h
+++ b/src/OpenAcc/io.h
@@ -27,7 +27,7 @@ static inline int save_conf(global_su3_soa * const conf_rw, const char* nomefile
 														int conf_id_iter, int use_ildg)
 {
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 	if(devinfo.myrank != 0){
 		printf("MPI%02d: Rank is not allowed to use this function!\n",devinfo.myrank );
 		printf("ERROR: %s:%d\n",__FILE__, __LINE__);
@@ -55,7 +55,7 @@ static inline void save_conf_wrapper(su3_soa* conf, const char* nomefile,
 	printf("MPI%02d - Saving whole configuration...\n", devinfo.myrank);
 	int writeOutcome;
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 
 	if(devinfo.myrank == 0){
 		int irank;
@@ -95,7 +95,7 @@ static inline int read_conf(global_su3_soa * conf, const char* nomefile,
 														int * conf_id_iter, int use_ildg)
 {
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 	if(devinfo.myrank != 0){
 		printf("MPI%02d: Rank is not allowed to use this function!\n",devinfo.myrank );
 		printf("ERROR: %s:%d\n",__FILE__, __LINE__);
@@ -123,7 +123,7 @@ static inline int read_conf_wrapper(su3_soa* conf, const char* nomefile,
 {
 
 	int error =  0;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 
 	if(devinfo.myrank == 0){
 		if(verbosity_lv > 2)

--- a/src/OpenAcc/io.h
+++ b/src/OpenAcc/io.h
@@ -31,7 +31,7 @@ static inline int save_conf(global_su3_soa * const conf_rw, const char* nomefile
 	if(devinfo.myrank != 0){
 		printf("MPI%02d: Rank is not allowed to use this function!\n",devinfo.myrank );
 		printf("ERROR: %s:%d\n",__FILE__, __LINE__);
-		MPI_Abort(MPI_COMM_WORLD,1);
+		MPI_Abort(devinfo.mpi_comm,1);
 	}
 #endif 
 
@@ -67,7 +67,7 @@ static inline void save_conf_wrapper(su3_soa* conf, const char* nomefile,
 	}
 	else send_lnh_subconf_to_master(conf,devinfo.myrank);
     
-	MPI_Bcast((void*) &writeOutcome,1,MPI_INT,0,MPI_COMM_WORLD);
+	MPI_Bcast((void*) &writeOutcome,1,MPI_INT,0,devinfo.mpi_comm);
 
 	if(0 != writeOutcome){
 		MPI_Finalize();
@@ -129,7 +129,7 @@ static inline int read_conf_wrapper(su3_soa* conf, const char* nomefile,
 		if(verbosity_lv > 2)
 			printf("MPI%02d - reading global conf \n",devinfo.myrank );
 		error = read_conf(conf_rw, nomefile,conf_id_iter, use_ildg);
-		MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+		MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 
 		if(!error) {
 			send_lnh_subconf_to_buffer(conf_rw,conf,0);
@@ -137,7 +137,7 @@ static inline int read_conf_wrapper(su3_soa* conf, const char* nomefile,
 			for(irank = 1 ; irank < devinfo.nranks; irank++)
 				send_lnh_subconf_to_rank(conf_rw,irank);
         
-			MPI_Bcast((void*) conf_id_iter,1,MPI_INT,0,MPI_COMM_WORLD);
+			MPI_Bcast((void*) conf_id_iter,1,MPI_INT,0,devinfo.mpi_comm);
 
 		}
 		else 
@@ -149,10 +149,10 @@ static inline int read_conf_wrapper(su3_soa* conf, const char* nomefile,
 		if(verbosity_lv > 2)
 			printf("MPI%02d - receiving conf \n",devinfo.myrank );
         
-		MPI_Bcast((void*) &error,1,MPI_INT,0,MPI_COMM_WORLD);
+		MPI_Bcast((void*) &error,1,MPI_INT,0,devinfo.mpi_comm);
 		if(!error){ 
 			receive_lnh_subconf_from_master(conf);
-			MPI_Bcast((void*) conf_id_iter,1,MPI_INT,0,MPI_COMM_WORLD);
+			MPI_Bcast((void*) conf_id_iter,1,MPI_INT,0,devinfo.mpi_comm);
 		}
 		else 
 			if(verbosity_lv > 2)

--- a/src/OpenAcc/io.h
+++ b/src/OpenAcc/io.h
@@ -27,9 +27,9 @@ static inline int save_conf(global_su3_soa * const conf_rw, const char* nomefile
 														int conf_id_iter, int use_ildg)
 {
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.myrank != 0){
-		printf("MPI%02d: Rank is not allowed to use this function!\n",devinfo.myrank );
+		MPI_PRINTF0("Rank is not allowed to use this function!\n" );
 		printf("ERROR: %s:%d\n",__FILE__, __LINE__);
 		MPI_Abort(devinfo.mpi_comm,1);
 	}
@@ -55,7 +55,7 @@ static inline void save_conf_wrapper(su3_soa* conf, const char* nomefile,
 	printf("MPI%02d - Saving whole configuration...\n", devinfo.myrank);
 	int writeOutcome;
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 
 	if(devinfo.myrank == 0){
 		int irank;
@@ -95,9 +95,9 @@ static inline int read_conf(global_su3_soa * conf, const char* nomefile,
 														int * conf_id_iter, int use_ildg)
 {
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.myrank != 0){
-		printf("MPI%02d: Rank is not allowed to use this function!\n",devinfo.myrank );
+		MPI_PRINTF0("Rank is not allowed to use this function!\n");
 		printf("ERROR: %s:%d\n",__FILE__, __LINE__);
 		exit(1);
 	}
@@ -123,7 +123,7 @@ static inline int read_conf_wrapper(su3_soa* conf, const char* nomefile,
 {
 
 	int error =  0;
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 
 	if(devinfo.myrank == 0){
 		if(verbosity_lv > 2)

--- a/src/OpenAcc/ipdot_gauge.c
+++ b/src/OpenAcc/ipdot_gauge.c
@@ -109,7 +109,7 @@ void calc_ipdot_gauge_soloopenacc_std(__restrict const su3_soa * const tconf_acc
 		}
 
 		#pragma acc update device(tconf_acc[0:8])
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 
@@ -122,7 +122,7 @@ void calc_ipdot_gauge_soloopenacc_std(__restrict const su3_soa * const tconf_acc
 		}
 
 		#pragma acc update device(tconf_acc[0:8])      
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 	
@@ -133,7 +133,7 @@ void calc_ipdot_gauge_soloopenacc_std(__restrict const su3_soa * const tconf_acc
 			single_su3_into_su3_soa(&tconf_acc[dir_link], idxh, &sto);
 
 		#pragma acc update device(tconf_acc[0:8])
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 
@@ -279,7 +279,7 @@ void calc_ipdot_gauge_soloopenacc_tlsm(__restrict const su3_soa * const tconf_ac
 		}
 
 		#pragma acc update device(tconf_acc[0:8])
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
       
@@ -293,7 +293,7 @@ void calc_ipdot_gauge_soloopenacc_tlsm(__restrict const su3_soa * const tconf_ac
 		}
 
 		#pragma acc update device(tconf_acc[0:8])      
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 	
@@ -304,7 +304,7 @@ void calc_ipdot_gauge_soloopenacc_tlsm(__restrict const su3_soa * const tconf_ac
 			single_su3_into_su3_soa(&tconf_acc[dir_link], idxh, &sto);
 
 		#pragma acc update device(tconf_acc[0:8])
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 
@@ -372,7 +372,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 	if(debug_settings.save_diagnostics == 1){
 		double  force_norm, diff_force_norm;
 		int printEvery = debug_settings.md_diag_print_every*md_parameters.gauge_scale;
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 		if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 			printEvery /= md_parameters.gauge_scale;
 #endif
@@ -387,7 +387,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 			diff_force_norm = calc_diff_force_norm(tipdot,ipdot_g_old)*BETA_BY_THREE;
 
 			double diff_force_norm_corrected = diff_force_norm;
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 			if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 				diff_force_norm_corrected /= (2*md_parameters.gauge_scale+1); 
 #endif
@@ -398,7 +398,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 				fprintf(foutfile,"%d\tGFHN %e\n%d\tDGFHN %e",
 								md_diag_count_gauge, force_norm,
 								md_diag_count_gauge, diff_force_norm_corrected);
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 				if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 					fprintf(foutfile,"  !!! [Not divided by (2ngs+1): %e ]", diff_force_norm);
 #endif
@@ -409,7 +409,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 				if(verbosity_lv > 1){
 					printf("\t\t\tGauge Force Half Norm: %e, Diff with previous: %e \n", 
 								 force_norm, diff_force_norm);
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 					if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 						printf("\t\t\t (Diff with end of previous gauge cycle)");
 #endif
@@ -423,7 +423,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 
 }
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void calc_ipdot_gauge_soloopenacc_std_bulk(__restrict const su3_soa * const tconf_acc, 
 																					 __restrict su3_soa * const local_staples,
 																					 __restrict tamat_soa * const tipdot)

--- a/src/OpenAcc/ipdot_gauge.c
+++ b/src/OpenAcc/ipdot_gauge.c
@@ -109,7 +109,7 @@ void calc_ipdot_gauge_soloopenacc_std(__restrict const su3_soa * const tconf_acc
 		}
 
 		#pragma acc update device(tconf_acc[0:8])
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 
@@ -122,7 +122,7 @@ void calc_ipdot_gauge_soloopenacc_std(__restrict const su3_soa * const tconf_acc
 		}
 
 		#pragma acc update device(tconf_acc[0:8])      
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 	
@@ -133,7 +133,7 @@ void calc_ipdot_gauge_soloopenacc_std(__restrict const su3_soa * const tconf_acc
 			single_su3_into_su3_soa(&tconf_acc[dir_link], idxh, &sto);
 
 		#pragma acc update device(tconf_acc[0:8])
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 
@@ -279,7 +279,7 @@ void calc_ipdot_gauge_soloopenacc_tlsm(__restrict const su3_soa * const tconf_ac
 		}
 
 		#pragma acc update device(tconf_acc[0:8])
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
       
@@ -293,7 +293,7 @@ void calc_ipdot_gauge_soloopenacc_tlsm(__restrict const su3_soa * const tconf_ac
 		}
 
 		#pragma acc update device(tconf_acc[0:8])      
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 	
@@ -304,7 +304,7 @@ void calc_ipdot_gauge_soloopenacc_tlsm(__restrict const su3_soa * const tconf_ac
 			single_su3_into_su3_soa(&tconf_acc[dir_link], idxh, &sto);
 
 		#pragma acc update device(tconf_acc[0:8])
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
     communicate_su3_borders(tconf_acc, GAUGE_HALO);  
 #endif
 
@@ -372,7 +372,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 	if(debug_settings.save_diagnostics == 1){
 		double  force_norm, diff_force_norm;
 		int printEvery = debug_settings.md_diag_print_every*md_parameters.gauge_scale;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 		if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 			printEvery /= md_parameters.gauge_scale;
 #endif
@@ -387,7 +387,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 			diff_force_norm = calc_diff_force_norm(tipdot,ipdot_g_old)*BETA_BY_THREE;
 
 			double diff_force_norm_corrected = diff_force_norm;
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 			if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 				diff_force_norm_corrected /= (2*md_parameters.gauge_scale+1); 
 #endif
@@ -398,7 +398,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 				fprintf(foutfile,"%d\tGFHN %e\n%d\tDGFHN %e",
 								md_diag_count_gauge, force_norm,
 								md_diag_count_gauge, diff_force_norm_corrected);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 				if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 					fprintf(foutfile,"  !!! [Not divided by (2ngs+1): %e ]", diff_force_norm);
 #endif
@@ -409,7 +409,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 				if(verbosity_lv > 1){
 					printf("\t\t\tGauge Force Half Norm: %e, Diff with previous: %e \n", 
 								 force_norm, diff_force_norm);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 					if(devinfo.nranks != 1 && devinfo.async_comm_gauge)
 						printf("\t\t\t (Diff with end of previous gauge cycle)");
 #endif
@@ -423,7 +423,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const su3_soa * const tconf_acc,
 
 }
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void calc_ipdot_gauge_soloopenacc_std_bulk(__restrict const su3_soa * const tconf_acc, 
 																					 __restrict su3_soa * const local_staples,
 																					 __restrict tamat_soa * const tipdot)

--- a/src/OpenAcc/ipdot_gauge.h
+++ b/src/OpenAcc/ipdot_gauge.h
@@ -23,7 +23,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const  su3_soa * const tconf_acc,
 																	__restrict su3_soa * const local_staples,
 																	__restrict tamat_soa * const tipdot);
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void calc_ipdot_gauge_soloopenacc_std_bulk(__restrict const  su3_soa * const tconf_acc, 
 																					 __restrict su3_soa * const local_staples,
 																					 __restrict tamat_soa * const tipdot);

--- a/src/OpenAcc/ipdot_gauge.h
+++ b/src/OpenAcc/ipdot_gauge.h
@@ -23,7 +23,7 @@ void calc_ipdot_gauge_soloopenacc(__restrict const  su3_soa * const tconf_acc,
 																	__restrict su3_soa * const local_staples,
 																	__restrict tamat_soa * const tipdot);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void calc_ipdot_gauge_soloopenacc_std_bulk(__restrict const  su3_soa * const tconf_acc, 
 																					 __restrict su3_soa * const local_staples,
 																					 __restrict tamat_soa * const tipdot);

--- a/src/OpenAcc/main.c
+++ b/src/OpenAcc/main.c
@@ -333,7 +333,7 @@ int main(int argc, char* argv[]){
     
 		if (0==devinfo.myrank_world) printf("%d/%d Defect initialization\n",r,rep->replicas_total_number); 
 		rep->label[r]=r;
-		init_k(conf_acc,rep->cr_vec[r],rep->defect_boundary,rep->defect_coordinates,&def,r);
+		init_k(conf_acc,rep->cr_vec[r],rep->defect_boundary,rep->defect_coordinates,&def,0);
 		
 #ifdef MULTIDEVICE
     if(devinfo.async_comm_gauge) init_k(&conf_acc[8],rep->cr_vec[r],rep->defect_boundary,rep->defect_coordinates,&def,1);
@@ -665,7 +665,7 @@ int main(int argc, char* argv[]){
 								iterations[r] = id_iter-id_iter_offset-accettate_therm[r]+1;
 								double acceptance = (double) accettate_metro[r] / iterations[r];
 								double acc_err = sqrt((double)accettate_metro[r]*(iterations[r]-accettate_metro[r])/iterations[r])/iterations[r];
-								printf("Estimated HMC acceptance for this run [replica %d]: %f +- %f\n. Iterations: %d",r,acceptance, acc_err, iterations[r]);
+								printf("Estimated HMC acceptance for this run [replica %d]: %f +- %f\n. Iterations: %d\n",r,acceptance, acc_err, iterations[r]);
 							}
 						}
 						#pragma acc update host(conf_acc[0:8])
@@ -689,7 +689,9 @@ int main(int argc, char* argv[]){
 							// conf swap
 							if (0==devinfo.myrank_world) {printf("CONF SWAP PROPOSED\n");}
               //TODO: reimplement without explicit swap, but at the label level in world root
-							All_Conf_SWAP(conf_acc,aux_conf_acc,local_sums, &def, &swap_number,all_swap_vector,acceptance_vector, rep);
+							//All_Conf_SWAP(conf_acc,aux_conf_acc,local_sums, &def, &swap_number,all_swap_vector,acceptance_vector, rep);
+              manage_replica_swaps(conf_acc, aux_conf_acc, local_sums, &def, &swap_number,all_swap_vector,acceptance_vector,rep);
+
 							if (0==devinfo.myrank_world) {printf("Number of accepted swaps: %d\n", swap_number);}       
 							#pragma acc update host(conf_acc[0:rep->replicas_total_number][0:8])
                 

--- a/src/OpenAcc/main.c
+++ b/src/OpenAcc/main.c
@@ -660,6 +660,7 @@ int main(int argc, char* argv[]){
 							#pragma acc update host(conf_acc[0:8])
                 
 							// periodic conf translation
+              lab=rep->label[devinfo.replica_idx];
               if(lab==0){
                 trasl_conf(conf_acc,auxbis_conf_acc);
               }

--- a/src/OpenAcc/main.c
+++ b/src/OpenAcc/main.c
@@ -702,7 +702,7 @@ int main(int argc, char* argv[]){
 							//action += - C_ONE  * BETA_BY_THREE * calc_rettangolo_soloopenacc(conf_acc[r], aux_conf_acc, local_sums);
 							action += - C_ONE  * BETA_BY_THREE * calc_rettangolo_soloopenacc(conf_acc, aux_conf_acc, local_sums);
 #endif
-							printf("ACTION AFTER HMC STEP REPLICA %d: %.15lg\n", r, action);
+							printf("ACTION AFTER HMC STEP REPLICA %d (lab %d): %.15lg\n", r, lab, action);
 						}
 
 #ifdef PAR_TEMP
@@ -711,13 +711,15 @@ int main(int argc, char* argv[]){
 							if (0==devinfo.myrank_world) {printf("CONF SWAP PROPOSED\n");}
               //TODO: reimplement without explicit swap, but at the label level in world root
 							//All_Conf_SWAP(conf_acc,aux_conf_acc,local_sums, &def, &swap_number,all_swap_vector,acceptance_vector, rep);
+
+              #pragma acc update host(conf_acc[0:alloc_info.conf_acc_size])
               manage_replica_swaps(conf_acc, aux_conf_acc, local_sums, &def, &swap_number,all_swap_vector,acceptance_vector,rep);
 
 							if (0==devinfo.myrank_world) {printf("Number of accepted swaps: %d\n", swap_number);}       
 							#pragma acc update host(conf_acc[0:rep->replicas_total_number][0:8])
                 
 							// periodic conf translation
-              if(r==0){
+              if(lab==0){
                 trasl_conf(conf_acc,auxbis_conf_acc);
               }
 						}

--- a/src/OpenAcc/main.c
+++ b/src/OpenAcc/main.c
@@ -84,7 +84,7 @@ int main(int argc, char* argv[]){
  
   gettimeofday ( &(mc_params.start_time), NULL );
   
-  if(0==devinfo.myrank){
+  if(0==devinfo.myrank_world){
     printf("****************************************************\n");
 		if (argc!=2) printf("          COMPILATION INFO                        \n");
     if (argc==2) printf("          PRE INIT - READING SETTING  FILE          \n");
@@ -94,16 +94,16 @@ int main(int argc, char* argv[]){
   }
   
   if (GAUGE_ACTION == 1 ){
-    if(0==devinfo.myrank) printf("\nCOMPILED WITH TREE-LEVEL SYMANZIK IMPROVED GAUGE ACTION\n\n");
+    if(0==devinfo.myrank_world) printf("\nCOMPILED WITH TREE-LEVEL SYMANZIK IMPROVED GAUGE ACTION\n\n");
   }
   else{
-    if(0==devinfo.myrank) printf("COMPILED WITH WILSON GAUGE ACTION\n\n");
+    if(0==devinfo.myrank_world) printf("COMPILED WITH WILSON GAUGE ACTION\n\n");
   }
 
 #ifdef PAR_TEMP
-  if(0==devinfo.myrank) printf("COMPILED FOR PARALLEL TEMPERING ON BOUNDARY CONDITIONS\n\n");
+  if(0==devinfo.myrank_world) printf("COMPILED FOR PARALLEL TEMPERING ON BOUNDARY CONDITIONS\n\n");
 #else
-  if(0==devinfo.myrank) printf("COMPILED WITHOUT PARALLEL TEMPERING (1 REPLICA RUN)\n\n");
+  if(0==devinfo.myrank_world) printf("COMPILED WITHOUT PARALLEL TEMPERING (1 REPLICA RUN)\n\n");
 #endif
 
   if(argc!=2){
@@ -1063,10 +1063,10 @@ int main(int argc, char* argv[]){
         }
 #ifdef MULTIDEVICE
 
-        MPI_Bcast((void*)&(mc_params.run_condition),1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*)&(mc_params.run_condition),1,MPI_INT,0,devinfo.mpi_comm);
         printf("MPI%02d - Broadcast of run condition %d from master...\n",
 							 devinfo.myrank, mc_params.run_condition);
-        MPI_Bcast((void*)&(mc_params.next_gps),1,MPI_INT,0,MPI_COMM_WORLD);
+        MPI_Bcast((void*)&(mc_params.next_gps),1,MPI_INT,0,devinfo.mpi_comm);
         printf("MPI%02d - Broadcast of next global program status %d from master...\n",
 							 devinfo.myrank, mc_params.next_gps);
 

--- a/src/OpenAcc/md_integrator.c
+++ b/src/OpenAcc/md_integrator.c
@@ -53,7 +53,7 @@
 #include "../Mpi/communications.h"
 #endif
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 
 #if defined(USE_MPI_CUDA_AWARE) || defined(__GNUC__)
 void multistep_2MN_gauge_async_bloc(su3_soa *tconf_acc_old, su3_soa *tconf_acc_new,
@@ -314,7 +314,7 @@ void multistep_2MN_gauge_bloc(su3_soa *tconf_acc,
 																	deltas_Omelyan,4);
 	gettimeofday ( &t[3], NULL );
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_su3_borders(tconf_acc,GAUGE_HALO);
 #endif
 	gettimeofday ( &t[4], NULL );
@@ -570,7 +570,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
 					 devinfo.myrank, md, md_parameters.no_md);
 		// step for the Q
 		// Q' = exp[dt/2 *i P] Q
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
 		if(devinfo.async_comm_gauge)
 			multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 		else 
@@ -603,7 +603,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
 
 		// Step for the Q
 		// Q' = exp[dt/2 *i P] Q
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
 		if(devinfo.async_comm_gauge)
 			multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 		else
@@ -657,7 +657,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
 				 devinfo.myrank,md_parameters.no_md);
 	// step for the Q
 	// Q' = exp[dt/2 *i P] Q
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
 	if(devinfo.async_comm_gauge)
 		multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 	else
@@ -695,7 +695,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
     
 	// step for the Q
 	// Q' = exp[dt/2 *i P] Q
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
 	if(devinfo.async_comm_gauge)
 		multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 	else 

--- a/src/OpenAcc/md_integrator.c
+++ b/src/OpenAcc/md_integrator.c
@@ -53,7 +53,7 @@
 #include "../Mpi/communications.h"
 #endif
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 
 #if defined(USE_MPI_CUDA_AWARE) || defined(__GNUC__)
 void multistep_2MN_gauge_async_bloc(su3_soa *tconf_acc_old, su3_soa *tconf_acc_new,
@@ -314,7 +314,7 @@ void multistep_2MN_gauge_bloc(su3_soa *tconf_acc,
 																	deltas_Omelyan,4);
 	gettimeofday ( &t[3], NULL );
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_su3_borders(tconf_acc,GAUGE_HALO);
 #endif
 	gettimeofday ( &t[4], NULL );
@@ -570,7 +570,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
 					 devinfo.myrank, md, md_parameters.no_md);
 		// step for the Q
 		// Q' = exp[dt/2 *i P] Q
-#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 		if(devinfo.async_comm_gauge)
 			multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 		else 
@@ -603,7 +603,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
 
 		// Step for the Q
 		// Q' = exp[dt/2 *i P] Q
-#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 		if(devinfo.async_comm_gauge)
 			multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 		else
@@ -657,7 +657,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
 				 devinfo.myrank,md_parameters.no_md);
 	// step for the Q
 	// Q' = exp[dt/2 *i P] Q
-#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.async_comm_gauge)
 		multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 	else
@@ -695,7 +695,7 @@ void multistep_2MN_SOLOOPENACC(tamat_soa * tipdot_acc,
     
 	// step for the Q
 	// Q' = exp[dt/2 *i P] Q
-#if NRANKS_D3 > 1 //#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	if(devinfo.async_comm_gauge)
 		multistep_2MN_gauge_async(tconf_acc,taux_conf_acc,tipdot_acc,tmomenta);
 	else 

--- a/src/OpenAcc/plaquettes.c
+++ b/src/OpenAcc/plaquettes.c
@@ -259,7 +259,7 @@ void calc_loc_staples_nnptrick_all_onlyferms(__restrict const su3_soa * const u,
 } // closes routine
 
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void calc_loc_staples_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																				__restrict su3_soa * const loc_stap )
 {

--- a/src/OpenAcc/plaquettes.c
+++ b/src/OpenAcc/plaquettes.c
@@ -259,7 +259,7 @@ void calc_loc_staples_nnptrick_all_onlyferms(__restrict const su3_soa * const u,
 } // closes routine
 
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void calc_loc_staples_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																				__restrict su3_soa * const loc_stap )
 {

--- a/src/OpenAcc/plaquettes.h
+++ b/src/OpenAcc/plaquettes.h
@@ -22,7 +22,7 @@ void calc_loc_staples_nnptrick_all_only_even(__restrict const su3_soa * const u,
 void calc_loc_staples_nnptrick_all_only_odd(__restrict const su3_soa * const u,
 																						__restrict su3_soa * const loc_stap);
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void calc_loc_staples_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																				__restrict su3_soa * const loc_stap);
 

--- a/src/OpenAcc/plaquettes.h
+++ b/src/OpenAcc/plaquettes.h
@@ -22,7 +22,7 @@ void calc_loc_staples_nnptrick_all_only_even(__restrict const su3_soa * const u,
 void calc_loc_staples_nnptrick_all_only_odd(__restrict const su3_soa * const u,
 																						__restrict su3_soa * const loc_stap);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void calc_loc_staples_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																				__restrict su3_soa * const loc_stap);
 

--- a/src/OpenAcc/random_assignement.c
+++ b/src/OpenAcc/random_assignement.c
@@ -86,7 +86,7 @@ void generate_vec3_soa_gauss(__restrict vec3_soa * const vect)
 																							vect->c2[t]=d_complex_gauss();
 																						}
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_fermion_borders_hostonly(vect);
 #endif
 }
@@ -203,7 +203,7 @@ void generate_Conf_cold(__restrict su3_soa * const conf,double factor)
 																								single_gl3_into_su3_soa(&conf[mu],t,&aux);
 
 																							}
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_su3_borders_hostonly(conf, HALO_WIDTH);
 #endif
 
@@ -243,7 +243,7 @@ void generate_vec3_soa_z2noise(__restrict vec3_soa * const vect)
 																								vect->c2[t]= -1.0 + 0.0*I;
 																							}
 																						}
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_fermion_borders_hostonly(vect);
 #endif
 

--- a/src/OpenAcc/random_assignement.c
+++ b/src/OpenAcc/random_assignement.c
@@ -86,7 +86,7 @@ void generate_vec3_soa_gauss(__restrict vec3_soa * const vect)
 																							vect->c2[t]=d_complex_gauss();
 																						}
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_fermion_borders_hostonly(vect);
 #endif
 }
@@ -178,7 +178,7 @@ void generate_Momenta_gauss(__restrict thmat_soa * const mom8)
 																							}   
 	}
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	// should not be necessary to communicate momenta, they are not propagated.
 	// communicate_thmat_soa_borders(mom8, HALO_WIDTH); 
 #endif
@@ -203,7 +203,7 @@ void generate_Conf_cold(__restrict su3_soa * const conf,double factor)
 																								single_gl3_into_su3_soa(&conf[mu],t,&aux);
 
 																							}
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_su3_borders_hostonly(conf, HALO_WIDTH);
 #endif
 
@@ -243,7 +243,7 @@ void generate_vec3_soa_z2noise(__restrict vec3_soa * const vect)
 																								vect->c2[t]= -1.0 + 0.0*I;
 																							}
 																						}
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_fermion_borders_hostonly(vect);
 #endif
 

--- a/src/OpenAcc/rectangles.c
+++ b/src/OpenAcc/rectangles.c
@@ -1052,7 +1052,7 @@ void calc_loc_improved_staples_typeABC_nnptrick_all(__restrict const su3_soa * c
   } // d3
 } // closes routine
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void calc_loc_improved_staples_typeA_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																											 __restrict su3_soa * const loc_stap )
 {
@@ -1900,7 +1900,7 @@ double calc_rettangolo_soloopenacc(__restrict const su3_soa * const tconf_acc,
       temp  += calc_loc_rectangles_1x2_nnptrick(tconf_acc,local_plaqs,tr_local_plaqs,mu,nu);
     }
   }
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
   MPI_Allreduce((void*)&temp,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else

--- a/src/OpenAcc/rectangles.c
+++ b/src/OpenAcc/rectangles.c
@@ -1052,7 +1052,7 @@ void calc_loc_improved_staples_typeABC_nnptrick_all(__restrict const su3_soa * c
   } // d3
 } // closes routine
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void calc_loc_improved_staples_typeA_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																											 __restrict su3_soa * const loc_stap )
 {
@@ -1900,7 +1900,7 @@ double calc_rettangolo_soloopenacc(__restrict const su3_soa * const tconf_acc,
       temp  += calc_loc_rectangles_1x2_nnptrick(tconf_acc,local_plaqs,tr_local_plaqs,mu,nu);
     }
   }
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
   MPI_Allreduce((void*)&temp,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else

--- a/src/OpenAcc/rectangles.c
+++ b/src/OpenAcc/rectangles.c
@@ -1901,7 +1901,7 @@ double calc_rettangolo_soloopenacc(__restrict const su3_soa * const tconf_acc,
   }
 #ifdef MULTIDEVICE
   MPI_Allreduce((void*)&temp,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
   total_result = temp;
 #endif 

--- a/src/OpenAcc/rectangles.c
+++ b/src/OpenAcc/rectangles.c
@@ -10,6 +10,7 @@
 
 #ifdef MULTIDEVICE
 #include <mpi.h>
+#include "../Mpi/multidev.h"
 #endif
 
 double calc_loc_rectangles_2x1_nnptrick(__restrict const su3_soa * const u,

--- a/src/OpenAcc/rectangles.h
+++ b/src/OpenAcc/rectangles.h
@@ -46,7 +46,7 @@ void calc_loc_improved_staples_typeC_nnptrick_all(__restrict const su3_soa * con
 void calc_loc_improved_staples_typeABC_nnptrick_all(__restrict const su3_soa * const u,__restrict su3_soa * const loc_stap );
 
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void calc_loc_improved_staples_typeA_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																											 __restrict su3_soa * const loc_stap );
 

--- a/src/OpenAcc/rectangles.h
+++ b/src/OpenAcc/rectangles.h
@@ -46,7 +46,7 @@ void calc_loc_improved_staples_typeC_nnptrick_all(__restrict const su3_soa * con
 void calc_loc_improved_staples_typeABC_nnptrick_all(__restrict const su3_soa * const u,__restrict su3_soa * const loc_stap );
 
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void calc_loc_improved_staples_typeA_nnptrick_all_bulk(__restrict const su3_soa * const u,
 																											 __restrict su3_soa * const loc_stap );
 

--- a/src/OpenAcc/stouting.c
+++ b/src/OpenAcc/stouting.c
@@ -31,7 +31,7 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 	int stoutsteps=(istopo & act_params.topo_action)?act_params.topo_stout_steps:act_params.stout_steps;
 		
 	if(verbosity_lv > 1) 
-		printf("MPI%02d:Stouting gauge conf %d times.\n",
+		printf("MPI%02d:%02d:Stouting gauge conf %d times.\n",devinfo.replica_idx,
 					 devinfo.myrank, stoutsteps);
 	if(stoutsteps > 0){
 		stout_isotropic(tconf_acc, tstout_conf_acc_arr, auxbis_conf_acc, 
@@ -41,10 +41,10 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 #endif
 		if(verbosity_lv > 4){
 			check_unitarity_device(tstout_conf_acc_arr,&max_unitarity_deviation,&avg_unitarity_deviation);
-			printf("MPI%02d:(Stout wrapper,1/%d) Avg_unitarity_deviation : %e\n",
-						 devinfo.myrank,stoutsteps,avg_unitarity_deviation);
-			printf("MPI%02d:(Stout wrapper,1/%d) Max_unitarity_deviation : %e\n",
-						 devinfo.myrank,stoutsteps,max_unitarity_deviation);
+			printf("MPI%02d:%02d:(Stout wrapper,1/%d) Avg_unitarity_deviation : %e\n",
+						 devinfo.replica_idx,devinfo.myrank,stoutsteps,avg_unitarity_deviation);
+			printf("MPI%02d:%02d:(Stout wrapper,1/%d) Max_unitarity_deviation : %e\n",
+						 devinfo.replica_idx,devinfo.myrank,stoutsteps,max_unitarity_deviation);
 		}
 
 		for(int stoutlevel=1;stoutlevel < stoutsteps;
@@ -61,6 +61,7 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 				check_unitarity_device(&tstout_conf_acc_arr[8*(stoutlevel-1)],
 															 &max_unitarity_deviation,&avg_unitarity_deviation);
 
+        //TODO: adapt all prints with replica index
 				printf("MPI%02d:(Stout wrapper,%d/%d) Avg_unitarity_deviation : %e\n",
 							 devinfo.myrank, stoutlevel+1,stoutsteps, 
 							 avg_unitarity_deviation);
@@ -85,7 +86,7 @@ void stout_isotropic(__restrict const su3_soa * const u, // input conf
 										 const int istopo) // istopo = {0,1} -> rho = {fermrho,toporho}
 {
 	if(verbosity_lv > 1) 
-		printf("MPI%02d: Isotropic stouting...\n",devinfo.myrank);
+		printf("MPI%02d:%02d: Isotropic stouting...\n",devinfo.replica_idx,devinfo.myrank);
 
 
 	set_su3_soa_to_zero(local_staples);
@@ -99,7 +100,7 @@ void stout_isotropic(__restrict const su3_soa * const u, // input conf
 	exp_minus_QA_times_conf(u,tipdot,uprime,auxiliary);
 
 	if(verbosity_lv > 1) 
-		printf("MPI%02d: Isotropic stouting done\n",devinfo.myrank);
+		printf("MPI%02d:%02d: Isotropic stouting done\n",devinfo.replica_idx,devinfo.myrank);
 }
 
 

--- a/src/OpenAcc/stouting.c
+++ b/src/OpenAcc/stouting.c
@@ -36,7 +36,7 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 	if(stoutsteps > 0){
 		stout_isotropic(tconf_acc, tstout_conf_acc_arr, auxbis_conf_acc, 
 										glocal_staples, gipdot, istopo);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 		communicate_su3_borders(tstout_conf_acc_arr,TRANSFER_THICKNESS);
 #endif
 		if(verbosity_lv > 4){
@@ -53,7 +53,7 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 			stout_isotropic(&(tstout_conf_acc_arr[8*(stoutlevel-1)]),
 											&(tstout_conf_acc_arr[8*stoutlevel]),auxbis_conf_acc,
 											glocal_staples,  gipdot, istopo);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 			communicate_su3_borders(
 															&(tstout_conf_acc_arr[8*stoutlevel]),TRANSFER_THICKNESS);
 #endif

--- a/src/OpenAcc/stouting.c
+++ b/src/OpenAcc/stouting.c
@@ -31,20 +31,17 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 	int stoutsteps=(istopo & act_params.topo_action)?act_params.topo_stout_steps:act_params.stout_steps;
 		
 	if(verbosity_lv > 1) 
-		printf("MPI%02d:%02d:Stouting gauge conf %d times.\n",devinfo.replica_idx,
-					 devinfo.myrank, stoutsteps);
+		MPI_PRINTF1(":Stouting gauge conf %d times.\n", stoutsteps);
 	if(stoutsteps > 0){
 		stout_isotropic(tconf_acc, tstout_conf_acc_arr, auxbis_conf_acc, 
 										glocal_staples, gipdot, istopo);
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 		communicate_su3_borders(tstout_conf_acc_arr,TRANSFER_THICKNESS);
 #endif
 		if(verbosity_lv > 4){
 			check_unitarity_device(tstout_conf_acc_arr,&max_unitarity_deviation,&avg_unitarity_deviation);
-			printf("MPI%02d:%02d:(Stout wrapper,1/%d) Avg_unitarity_deviation : %e\n",
-						 devinfo.replica_idx,devinfo.myrank,stoutsteps,avg_unitarity_deviation);
-			printf("MPI%02d:%02d:(Stout wrapper,1/%d) Max_unitarity_deviation : %e\n",
-						 devinfo.replica_idx,devinfo.myrank,stoutsteps,max_unitarity_deviation);
+			MPI_PRINTF1(":(Stout wrapper,1/%d) Avg_unitarity_deviation : %e\n",stoutsteps,avg_unitarity_deviation);
+			MPI_PRINTF1(":(Stout wrapper,1/%d) Max_unitarity_deviation : %e\n",stoutsteps,max_unitarity_deviation);
 		}
 
 		for(int stoutlevel=1;stoutlevel < stoutsteps;
@@ -53,7 +50,7 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 			stout_isotropic(&(tstout_conf_acc_arr[8*(stoutlevel-1)]),
 											&(tstout_conf_acc_arr[8*stoutlevel]),auxbis_conf_acc,
 											glocal_staples,  gipdot, istopo);
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 			communicate_su3_borders(
 															&(tstout_conf_acc_arr[8*stoutlevel]),TRANSFER_THICKNESS);
 #endif
@@ -62,12 +59,8 @@ void stout_wrapper(__restrict const su3_soa * const tconf_acc,
 															 &max_unitarity_deviation,&avg_unitarity_deviation);
 
         //TODO: adapt all prints with replica index
-				printf("MPI%02d:(Stout wrapper,%d/%d) Avg_unitarity_deviation : %e\n",
-							 devinfo.myrank, stoutlevel+1,stoutsteps, 
-							 avg_unitarity_deviation);
-				printf("MPI%02d:(Stout wrapper,%d/%d) Max_unitarity_deviation : %e\n",
-							 devinfo.myrank, stoutlevel+1,stoutsteps, 
-							 max_unitarity_deviation);
+				MPI_PRINTF1("(Stout wrapper,%d/%d) Avg_unitarity_deviation : %e\n", stoutlevel+1,stoutsteps, avg_unitarity_deviation);
+				MPI_PRINTF1("(Stout wrapper,%d/%d) Max_unitarity_deviation : %e\n", stoutlevel+1,stoutsteps, max_unitarity_deviation);
 			}
 
 		}
@@ -86,7 +79,7 @@ void stout_isotropic(__restrict const su3_soa * const u, // input conf
 										 const int istopo) // istopo = {0,1} -> rho = {fermrho,toporho}
 {
 	if(verbosity_lv > 1) 
-		printf("MPI%02d:%02d: Isotropic stouting...\n",devinfo.replica_idx,devinfo.myrank);
+		MPI_PRINTF0("Isotropic stouting...\n");
 
 
 	set_su3_soa_to_zero(local_staples);
@@ -100,7 +93,7 @@ void stout_isotropic(__restrict const su3_soa * const u, // input conf
 	exp_minus_QA_times_conf(u,tipdot,uprime,auxiliary);
 
 	if(verbosity_lv > 1) 
-		printf("MPI%02d:%02d: Isotropic stouting done\n",devinfo.replica_idx,devinfo.myrank);
+		MPI_PRINTF0("Isotropic stouting done\n");
 }
 
 

--- a/src/OpenAcc/su3_measurements.c
+++ b/src/OpenAcc/su3_measurements.c
@@ -156,7 +156,7 @@ double calc_momenta_action( const __restrict thmat_soa * const mom,
 	}
 
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -203,7 +203,7 @@ double  calc_plaquette_soloopenacc(__restrict  su3_soa * const tconf_acc,
 		}
 	}
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -230,7 +230,7 @@ double calc_force_norm(const __restrict tamat_soa * tipdot)
 				result += half_tr_tamat_squared(&tipdot[mu],t);
 			}
 	}  
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -267,7 +267,7 @@ double calc_diff_force_norm(const __restrict tamat_soa * tipdot,
 			}
     }  
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -304,7 +304,7 @@ double calc_sum_momenta_norm(const __restrict thmat_soa * tmomenta,
 			}
     }  
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -344,7 +344,7 @@ double calc_diff_su3_soa_norm(const __restrict su3_soa * tconf,
 			}
     }  
 
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else

--- a/src/OpenAcc/su3_measurements.c
+++ b/src/OpenAcc/su3_measurements.c
@@ -157,7 +157,7 @@ double calc_momenta_action( const __restrict thmat_soa * const mom,
 
 #ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
 	total_result = result;
 #endif
@@ -204,7 +204,7 @@ double  calc_plaquette_soloopenacc(__restrict  su3_soa * const tconf_acc,
 
 #ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
 	total_result = result;
 #endif
@@ -231,7 +231,7 @@ double calc_force_norm(const __restrict tamat_soa * tipdot)
 	}  
 #ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
 	total_result = result;
 #endif
@@ -268,7 +268,7 @@ double calc_diff_force_norm(const __restrict tamat_soa * tipdot,
 
 #ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
 	total_result = result;
 #endif
@@ -305,7 +305,7 @@ double calc_sum_momenta_norm(const __restrict thmat_soa * tmomenta,
 
 #ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
 	total_result = result;
 #endif
@@ -345,7 +345,7 @@ double calc_diff_su3_soa_norm(const __restrict su3_soa * tconf,
 
 #ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
-								1,MPI_DOUBLE,MPI_SUM,MPI_COMM_WORLD);
+								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
 	total_result = result;
 #endif

--- a/src/OpenAcc/su3_measurements.c
+++ b/src/OpenAcc/su3_measurements.c
@@ -15,6 +15,7 @@
 
 #ifdef MULTIDEVICE
 #include <mpi.h>
+#include "../Mpi/multidev.h"
 #endif
 
 

--- a/src/OpenAcc/su3_measurements.c
+++ b/src/OpenAcc/su3_measurements.c
@@ -156,7 +156,7 @@ double calc_momenta_action( const __restrict thmat_soa * const mom,
 	}
 
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -203,7 +203,7 @@ double  calc_plaquette_soloopenacc(__restrict  su3_soa * const tconf_acc,
 		}
 	}
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -230,7 +230,7 @@ double calc_force_norm(const __restrict tamat_soa * tipdot)
 				result += half_tr_tamat_squared(&tipdot[mu],t);
 			}
 	}  
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -267,7 +267,7 @@ double calc_diff_force_norm(const __restrict tamat_soa * tipdot,
 			}
     }  
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -304,7 +304,7 @@ double calc_sum_momenta_norm(const __restrict thmat_soa * tmomenta,
 			}
     }  
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else
@@ -344,7 +344,7 @@ double calc_diff_su3_soa_norm(const __restrict su3_soa * tconf,
 			}
     }  
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	MPI_Allreduce((void*)&result,(void*)&total_result,
 								1,MPI_DOUBLE,MPI_SUM,devinfo.mpi_comm);
 #else

--- a/src/OpenAcc/su3_utilities.c
+++ b/src/OpenAcc/su3_utilities.c
@@ -308,7 +308,7 @@ void mom_exp_times_conf_soloopenacc(__restrict su3_soa * const conf,
 
 }
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 
 void set_su3_soa_to_zero_bulk(__restrict su3_soa * const matrix)
 {
@@ -603,7 +603,7 @@ void add_defect_coeffs_to_staple(__restrict const su3_soa * const u,
 	}
 }
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 // same as <add_defect_coeffs_to_staple> but only for links living on the bulk
 void add_defect_coeffs_to_staple_bulk(__restrict const su3_soa * const u,
 																			__restrict su3_soa * const loc_stap)

--- a/src/OpenAcc/su3_utilities.c
+++ b/src/OpenAcc/su3_utilities.c
@@ -308,7 +308,7 @@ void mom_exp_times_conf_soloopenacc(__restrict su3_soa * const conf,
 
 }
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 
 void set_su3_soa_to_zero_bulk(__restrict su3_soa * const matrix)
 {
@@ -603,7 +603,7 @@ void add_defect_coeffs_to_staple(__restrict const su3_soa * const u,
 	}
 }
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 // same as <add_defect_coeffs_to_staple> but only for links living on the bulk
 void add_defect_coeffs_to_staple_bulk(__restrict const su3_soa * const u,
 																			__restrict su3_soa * const loc_stap)

--- a/src/OpenAcc/su3_utilities.h
+++ b/src/OpenAcc/su3_utilities.h
@@ -1642,7 +1642,7 @@ static inline void mom_exp_times_conf_soloopenacc_loc_split(const __restrict thm
 
 }
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 
 void set_su3_soa_to_zero_bulk(__restrict su3_soa * const matrix);
 
@@ -1690,7 +1690,7 @@ void mom_exp_times_conf_soloopenacc_d3c(__restrict const su3_soa * const conf_ol
 void add_defect_coeffs_to_staple(__restrict const su3_soa * const u,
 																 __restrict su3_soa * const loc_stap);
 
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 void add_defect_coeffs_to_staple_bulk(__restrict const su3_soa * const u,
 																			__restrict su3_soa * const loc_stap);
 

--- a/src/OpenAcc/su3_utilities.h
+++ b/src/OpenAcc/su3_utilities.h
@@ -1642,7 +1642,7 @@ static inline void mom_exp_times_conf_soloopenacc_loc_split(const __restrict thm
 
 }
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 
 void set_su3_soa_to_zero_bulk(__restrict su3_soa * const matrix);
 
@@ -1690,7 +1690,7 @@ void mom_exp_times_conf_soloopenacc_d3c(__restrict const su3_soa * const conf_ol
 void add_defect_coeffs_to_staple(__restrict const su3_soa * const u,
 																 __restrict su3_soa * const loc_stap);
 
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 void add_defect_coeffs_to_staple_bulk(__restrict const su3_soa * const u,
 																			__restrict su3_soa * const loc_stap);
 

--- a/src/OpenAcc/topological_force.c
+++ b/src/OpenAcc/topological_force.c
@@ -159,7 +159,7 @@ void topo_staples(__restrict su3_soa * u,__restrict su3_soa * const staples, dou
     printf("\t\t\tMPI%02d - four_leaves(leaves,u)\n",devinfo.myrank);
   
   // compute leaves
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_su3_borders(u, GAUGE_HALO);  
 #endif
 
@@ -173,7 +173,7 @@ void topo_staples(__restrict su3_soa * u,__restrict su3_soa * const staples, dou
   
   antihermatize_unsafe(leaves);
   
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
 	communicate_gl3_borders(leaves, GAUGE_HALO);  
 #endif
 

--- a/src/OpenAcc/topological_force.c
+++ b/src/OpenAcc/topological_force.c
@@ -24,9 +24,8 @@
 #include "./alloc_vars.h"
 
 #define ALLOLLOCHECK(control_int,var)  if(control_int != 0 )						\
-    printf("MPI%02d: \tError in  allocation of %s . \n",devinfo.myrank, #var); \
-	else if(verbosity_lv > 2) printf("MPI%02d: \tAllocation of %s : OK , %p\n",	\
-																	 devinfo.myrank, #var, var );
+    MPI_PRINTF1("\tError in  allocation of %s . \n", #var); \
+	else if(verbosity_lv > 2) MPI_PRINTF1("\tAllocation of %s : OK , %p\n", #var, var );
 
 #define FREELOLLOCHECK(var) if(verbosity_lv >2)					\
     printf("\tFreed %s, %p ...", #var,var);							\
@@ -159,7 +158,7 @@ void topo_staples(__restrict su3_soa * u,__restrict su3_soa * const staples, dou
     printf("\t\t\tMPI%02d - four_leaves(leaves,u)\n",devinfo.myrank);
   
   // compute leaves
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_su3_borders(u, GAUGE_HALO);  
 #endif
 
@@ -173,7 +172,7 @@ void topo_staples(__restrict su3_soa * u,__restrict su3_soa * const staples, dou
   
   antihermatize_unsafe(leaves);
   
-#if NRANKS_D3 > 1	//#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 	communicate_gl3_borders(leaves, GAUGE_HALO);  
 #endif
 

--- a/src/OpenAcc/update_versatile.c
+++ b/src/OpenAcc/update_versatile.c
@@ -142,7 +142,6 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 	#pragma acc update device(ferm_phi_acc[0:alloc_info.NPS_tot])
 
 	gconf_as_fermionmatrix_f = conf_acc_f;
-	// ^^^ WARNING: this works only for sequential replicas updating. If you want to parallelize it, use conf_acc_f[replica_id].
 #ifdef STOUT_FERMIONS
 	// dilation using stouted dirac operator
 	// stouting... (already on device)
@@ -298,7 +297,6 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 		// conversion double to float
 
 		su3_soa_f * tconf_acc_f = conf_acc_f;
-		// ^^^ WARNING: this works only for sequential replicas updating. If you want to parallelize it, use conf_acc_f[replica_id].
 
 		printf("Converting momenta...\n");
 		convert_double_to_float_thmat_soa(momenta,momenta_f);
@@ -585,8 +583,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 	if(metro==1){
 		if(accepted==1){
 			acc++;
-			printf("MPI%02d,ACCEPTED   ---> [acc/iter] = [%i/%i] \n",
-						 devinfo.myrank,acc,iterazioni);
+			MPI_PRINTF1("  ---> [acc/iter] = [%i/%i] \n",acc,iterazioni);
 			// configuration accepted set_su3_soa_to_su3_soa(arg1,arg2) ===> arg2=arg1;
 			set_su3_soa_to_su3_soa(tconf_acc,conf_acc_bkp);
 		}else{

--- a/src/OpenAcc/update_versatile.c
+++ b/src/OpenAcc/update_versatile.c
@@ -490,7 +490,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 				recombine_shifted_vec3_to_vec3(ferm_shiftmulti_acc, &(ferm_chi_acc[ps_index]), &(ferm_phi_acc[ps_index]),&(fermions_parameters[iflav].approx_li));
 			}
 		} // end iflav
-		printf(" MPI%02d - Final Action Computed : OK \n", devinfo.myrank);
+		MPI_PRINTF0("- Final Action Computed : OK \n")
 
 		// I should not modify the action computation...well actually yes. I Should modify the way action is computed.
 		// I have only to change the gauge action
@@ -537,17 +537,12 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 		// delta_S = action_new - action_old
 		delta_S  = - (-action_in+action_mom_in+action_ferm_in+action_topo_in) + (-action_fin+action_mom_fin+action_ferm_fin+action_topo_fin);
 		if(verbosity_lv > 2 && 0 == devinfo.myrank ){
-			printf("MPI%02d-iterazione %i:  Gauge_ACTION  (in and out) = %.18lf , %.18lf\n",
-						 devinfo.myrank,iterazioni,-action_in,-action_fin);
-			printf("MPI%02d-iterazione %i:  Topol_ACTION  (in and out) = %.18lf , %.18lf\n",
-						 devinfo.myrank,iterazioni,+action_topo_in,+action_topo_fin);
-			printf("MPI%02d-iterazione %i:  Momen_ACTION  (in and out) = %.18lf , %.18lf\n",
-						 devinfo.myrank,iterazioni,action_mom_in,action_mom_fin);
-			printf("MPI%02d-iterazione %i:  Fermi_ACTION  (in and out) = %.18lf , %.18lf\n",
-						 devinfo.myrank,iterazioni,action_ferm_in,action_ferm_fin);
+			MPI_PRINTF1("-iterazione %i:  Gauge_ACTION  (in and out) = %.18lf , %.18lf\n",iterazioni,-action_in,-action_fin);
+			MPI_PRINTF1("-iterazione %i:  Topol_ACTION  (in and out) = %.18lf , %.18lf\n",iterazioni,+action_topo_in,+action_topo_fin);
+			MPI_PRINTF1("-iterazione %i:  Momen_ACTION  (in and out) = %.18lf , %.18lf\n",iterazioni,action_mom_in,action_mom_fin);
+			MPI_PRINTF1("-iterazione %i:  Fermi_ACTION  (in and out) = %.18lf , %.18lf\n",iterazioni,action_ferm_in,action_ferm_fin);
 		}       
-		printf("MPI%02d-iterazione %i:  DELTA_ACTION = %.18lf. ",
-					 devinfo.myrank,iterazioni,delta_S);
+		MPI_PRINTF1("-iterazione %i:  DELTA_ACTION = %.18lf. ",iterazioni,delta_S);
 
 
 		if(debug_settings.do_norandom_test) // NORANDOM
@@ -564,7 +559,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 					if(0==devinfo.myrank)p2=casuale();
 #if NRANKS_D3 > 1 // #ifedf MULTIDEVICE
 					MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
-					printf("MPI%02d p2 : %f, p1 %f \n",devinfo.myrank, p2,p1);
+					MPI_PRINTF1("p2 : %f, p1 %f \n", p2,p1);
 #endif
 				}
 				if(p2<p1)
@@ -583,11 +578,11 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 	if(metro==1){
 		if(accepted==1){
 			acc++;
-			MPI_PRINTF1("  ---> [acc/iter] = [%i/%i] \n",acc,iterazioni);
+			MPI_PRINTF1(" ---> [acc/iter] = [%i/%i] \n",acc,iterazioni);
 			// configuration accepted set_su3_soa_to_su3_soa(arg1,arg2) ===> arg2=arg1;
 			set_su3_soa_to_su3_soa(tconf_acc,conf_acc_bkp);
 		}else{
-			MPI_PRINTF1("  ---> [acc/iter] = [%i/%i] \n",acc,iterazioni);
+			MPI_PRINTF1(" ---> [acc/iter] = [%i/%i] \n",acc,iterazioni);
 			// configuration rejected set_su3_soa_to_su3_soa(arg1,arg2) ===> arg2=arg1;
 			set_su3_soa_to_su3_soa(conf_acc_bkp,tconf_acc);
 			#pragma acc update device(tconf_acc[0:8])
@@ -661,7 +656,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 		fprintf(foutfile,"GCOMMTIME %e\n",gauge_mdtimes.communicationsTime       / gauge_mdtimes.count );
 		gaugeMdCountersReset(&gauge_mdtimes);
 #if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
-		if( ! devinfo.async_comm_fermion){
+		if( !devinfo.async_comm_fermion){
 			fprintf(foutfile,"FCOMMTIME %e\n", dirac_times.totTransferTime       / dirac_times.count );
 
 			diracCountersReset(&dirac_times);

--- a/src/OpenAcc/update_versatile.c
+++ b/src/OpenAcc/update_versatile.c
@@ -557,7 +557,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 				if(debug_settings.do_norandom_test) p2=0; // NORANDOM
 				else{ // NORMAL, RANDOM
 					if(0==devinfo.myrank)p2=casuale();
-#if NRANKS_D3 > 1 // #ifedf MULTIDEVICE
+#if NRANKS_D3 > 1
 					MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
 					MPI_PRINTF1("p2 : %f, p1 %f \n", p2,p1);
 #endif
@@ -655,7 +655,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 		fprintf(foutfile,"GCOSTTIME %e\n",gauge_mdtimes.communicationsStartTime  / gauge_mdtimes.count );
 		fprintf(foutfile,"GCOMMTIME %e\n",gauge_mdtimes.communicationsTime       / gauge_mdtimes.count );
 		gaugeMdCountersReset(&gauge_mdtimes);
-#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
+#if NRANKS_D3 > 1
 		if( !devinfo.async_comm_fermion){
 			fprintf(foutfile,"FCOMMTIME %e\n", dirac_times.totTransferTime       / dirac_times.count );
 

--- a/src/OpenAcc/update_versatile.c
+++ b/src/OpenAcc/update_versatile.c
@@ -575,7 +575,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 				else{ // NORMAL, RANDOM
 					if(0==devinfo.myrank)p2=casuale();
 #ifdef MULTIDEVICE
-					MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,MPI_COMM_WORLD);
+					MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
 					printf("MPI%02d p2 : %f, p1 %f \n",devinfo.myrank, p2,p1);
 #endif
 				}

--- a/src/OpenAcc/update_versatile.c
+++ b/src/OpenAcc/update_versatile.c
@@ -142,7 +142,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 	} // end for iflav
 	#pragma acc update device(ferm_phi_acc[0:alloc_info.NPS_tot])
 
-	gconf_as_fermionmatrix_f = conf_acc_f[0];
+	gconf_as_fermionmatrix_f = conf_acc_f;
 	// ^^^ WARNING: this works only for sequential replicas updating. If you want to parallelize it, use conf_acc_f[replica_id].
 #ifdef STOUT_FERMIONS
 	// dilation using stouted dirac operator
@@ -298,7 +298,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 
 		// conversion double to float
 
-		su3_soa_f * tconf_acc_f = conf_acc_f[0];
+		su3_soa_f * tconf_acc_f = conf_acc_f;
 		// ^^^ WARNING: this works only for sequential replicas updating. If you want to parallelize it, use conf_acc_f[replica_id].
 
 		printf("Converting mommenta...\n");

--- a/src/OpenAcc/update_versatile.c
+++ b/src/OpenAcc/update_versatile.c
@@ -562,7 +562,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 				if(debug_settings.do_norandom_test) p2=0; // NORANDOM
 				else{ // NORMAL, RANDOM
 					if(0==devinfo.myrank)p2=casuale();
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifedf MULTIDEVICE
 					MPI_Bcast((void*) &p2,1,MPI_DOUBLE,0,devinfo.mpi_comm);
 					printf("MPI%02d p2 : %f, p1 %f \n",devinfo.myrank, p2,p1);
 #endif
@@ -660,7 +660,7 @@ int UPDATE_SOLOACC_UNOSTEP_VERSATILE(su3_soa *tconf_acc,
 		fprintf(foutfile,"GCOSTTIME %e\n",gauge_mdtimes.communicationsStartTime  / gauge_mdtimes.count );
 		fprintf(foutfile,"GCOMMTIME %e\n",gauge_mdtimes.communicationsTime       / gauge_mdtimes.count );
 		gaugeMdCountersReset(&gauge_mdtimes);
-#ifdef MULTIDEVICE
+#if NRANKS_D3 > 1 // #ifdef MULTIDEVICE
 		if( ! devinfo.async_comm_fermion){
 			fprintf(foutfile,"FCOMMTIME %e\n", dirac_times.totTransferTime       / dirac_times.count );
 

--- a/src/tests_and_benchmarks/deo_doe_test.c
+++ b/src/tests_and_benchmarks/deo_doe_test.c
@@ -188,7 +188,7 @@ int main(int argc, char* argv[]){
 
     // INITIALIZING GAUGE CONFIGURATION
     int conf_id_iter = 0;
-    if(!read_conf_wrapper(conf_acc[0],mc_params.save_conf_name,
+    if(!read_conf_wrapper(conf_acc,mc_params.save_conf_name,
                 &conf_id_iter,debug_settings.use_ildg)){
         // READS ALSO THE conf_id_iter
         printf("MPI%02d - Stored Gauge Conf \"%s\" Read : OK \n",
@@ -196,15 +196,15 @@ int main(int argc, char* argv[]){
 
     }
     else{
-        generate_Conf_cold(conf_acc[0],mc_params.eps_gen);
+        generate_Conf_cold(conf_acc,mc_params.eps_gen);
         printf("MPI%02d - Cold Gauge Conf Generated : OK \n",
                 devinfo.myrank);
-        save_conf_wrapper(conf_acc[0],mc_params.save_conf_name,0,debug_settings.use_ildg);
+        save_conf_wrapper(conf_acc,mc_params.save_conf_name,0,debug_settings.use_ildg);
         if(debug_settings.use_ildg)
             printf("MPI%02d: You're using ILDG format.\n", devinfo.myrank);
         conf_id_iter=0;
     }
-#pragma acc update device(conf_acc[0:1][0:8])
+#pragma acc update device(conf_acc[0:8])
 
 
     // init fermion
@@ -235,7 +235,7 @@ int main(int argc, char* argv[]){
         printf("Multiplication by Doe, %d times...\n", test_settings.deoDoeIterations);
     gettimeofday(&t0,NULL);
     for(r=0; r<test_settings.deoDoeIterations; r++)
-        acc_Doe(conf_acc[0], ferm_phi_acc, ferm_chi_acc, fermions_parameters[0].phases);
+        acc_Doe(conf_acc, ferm_phi_acc, ferm_chi_acc, fermions_parameters[0].phases);
     gettimeofday(&t1,NULL);
 
     if(test_settings.saveResults){
@@ -250,7 +250,7 @@ int main(int argc, char* argv[]){
         printf("Multiplication by Deo, %d times...\n", test_settings.deoDoeIterations);
     gettimeofday(&t2,NULL);
     for(r=0; r<test_settings.deoDoeIterations; r++)
-        acc_Deo(conf_acc[0], ferm_phi_acc, ferm_chi_acc,fermions_parameters[0].phases);
+        acc_Deo(conf_acc, ferm_phi_acc, ferm_chi_acc,fermions_parameters[0].phases);
     gettimeofday(&t3,NULL);
 
     if(test_settings.saveResults){
@@ -265,7 +265,7 @@ int main(int argc, char* argv[]){
         printf("Multiplication by M^\\dagM+m^2, %d times...\n", test_settings.deoDoeIterations);
     gettimeofday(&t4,NULL);
     for(r=0; r<test_settings.deoDoeIterations; r++)
-        fermion_matrix_multiplication(conf_acc[0], ferm_phi_acc, 
+        fermion_matrix_multiplication(conf_acc, ferm_phi_acc, 
                 ferm_chi_acc, kloc_s, &fermions_parameters[0]) ;
     gettimeofday(&t5,NULL);
 
@@ -293,7 +293,7 @@ int main(int argc, char* argv[]){
                 dt_dirac/test_settings.deoDoeIterations);
     }
     // conversion to single precision
-    convert_double_to_float_su3_soa(conf_acc[0],conf_acc_f[0]);
+    convert_double_to_float_su3_soa(conf_acc,conf_acc_f);
     convert_double_to_float_vec3_soa(ferm_chi_acc,ferm_chi_acc_f);
 
     // single precision
@@ -308,7 +308,7 @@ int main(int argc, char* argv[]){
         printf("Multiplication by Doe, %d times...\n", test_settings.deoDoeIterations);
     gettimeofday(&t0_f,NULL);
     for(r=0; r<test_settings.deoDoeIterations; r++)
-        acc_Doe_f(conf_acc_f[0], ferm_phi_acc_f, ferm_chi_acc_f, fermions_parameters[0].phases_f);
+        acc_Doe_f(conf_acc_f, ferm_phi_acc_f, ferm_chi_acc_f, fermions_parameters[0].phases_f);
     gettimeofday(&t1_f,NULL);
 
 
@@ -324,7 +324,7 @@ int main(int argc, char* argv[]){
         printf("Multiplication by Deo, %d times...\n", test_settings.deoDoeIterations);
     gettimeofday(&t2_f,NULL);
     for(r=0; r<test_settings.deoDoeIterations; r++)
-        acc_Deo_f(conf_acc_f[0], ferm_phi_acc_f, ferm_chi_acc_f, fermions_parameters[0].phases_f) ;
+        acc_Deo_f(conf_acc_f, ferm_phi_acc_f, ferm_chi_acc_f, fermions_parameters[0].phases_f) ;
     gettimeofday(&t3_f,NULL);
 
     if(test_settings.saveResults){
@@ -339,7 +339,7 @@ int main(int argc, char* argv[]){
         printf("Multiplication by M^\\dagM+m^2, %d times...\n", test_settings.deoDoeIterations);
     gettimeofday(&t4_f,NULL);
     for(r=0; r<test_settings.deoDoeIterations; r++)
-        fermion_matrix_multiplication_f(conf_acc_f[0], ferm_phi_acc_f, 
+        fermion_matrix_multiplication_f(conf_acc_f, ferm_phi_acc_f, 
                 ferm_chi_acc_f, kloc_s_f, &fermions_parameters[0]) ;
     gettimeofday(&t5_f,NULL);
 

--- a/src/tests_and_benchmarks/inverter_multishift_test.c
+++ b/src/tests_and_benchmarks/inverter_multishift_test.c
@@ -184,7 +184,7 @@ int main(int argc, char* argv[]){
 
     // INITIALIZING GAUGE CONFIGURATION
     int conf_id_iter = 0;
-    if(!read_conf_wrapper(conf_acc[0],mc_params.save_conf_name,
+    if(!read_conf_wrapper(conf_acc,mc_params.save_conf_name,
                 &conf_id_iter,debug_settings.use_ildg)){
         // READS ALSO THE conf_id_iter
         printf("MPI%02d - Stored Gauge Conf \"%s\" Read : OK \n",
@@ -192,16 +192,16 @@ int main(int argc, char* argv[]){
 
     }
     else{
-        generate_Conf_cold(conf_acc[0],mc_params.eps_gen);
+        generate_Conf_cold(conf_acc,mc_params.eps_gen);
         printf("MPI%02d - Cold Gauge Conf Generated : OK \n",
                 devinfo.myrank);
         if(test_settings.saveResults)
-            save_conf_wrapper(conf_acc[0],mc_params.save_conf_name,0,debug_settings.use_ildg);
+            save_conf_wrapper(conf_acc,mc_params.save_conf_name,0,debug_settings.use_ildg);
         if(debug_settings.use_ildg)
             printf("MPI%02d: You're using ILDG format.\n", devinfo.myrank);
         conf_id_iter=0;
     }
-#pragma acc update device(conf_acc[0:1][0:8])
+#pragma acc update device(conf_acc[0:8])
 
 
     // init fermion
@@ -227,11 +227,11 @@ int main(int argc, char* argv[]){
 
     RationalApprox * rationalApproxToUse;
     /*
-#pragma acc data  copy(conf_acc[0][0:8]) copy(ferm_chi_acc[0:1])\
+#pragma acc data  copy(conf_acc[0:8]) copy(ferm_chi_acc[0:1])\
 copy(ferm_phi_acc[0:1])  copy(u1_back_phases[0:8*alloc_info.NDiffFlavs]) \
 create(kloc_r[0:1]) create(kloc_h[0:1]) create(kloc_s[0:1]) create(kloc_p[0:1]) \
 create(ferm_shiftmulti_acc[0:alloc_info.maxNeededShifts]) \
-copy(conf_acc_f[0][0:8]) copy(ferm_chi_acc_f[0:1])\
+copy(conf_acc_f[0:8]) copy(ferm_chi_acc_f[0:1])\
 copy(ferm_phi_acc_f[0:1])  copy(u1_back_phases_f[0:8*alloc_info.NDiffFlavs]) \
 create(kloc_r_f[0:1]) create(kloc_h_f[0:1])\
 create(kloc_s_f[0:1]) create(kloc_p_f[0:1]) \
@@ -252,7 +252,7 @@ create(k_p_shiftferm_f[0:alloc_info.maxApproxOrder] )
         double minmaxeig[2];
         generate_vec3_soa_gauss(kloc_p);
 #pragma acc update device(kloc_p[0:1])
-        find_min_max_eigenvalue_soloopenacc(conf_acc[0],fermions_parameters,kloc_r,kloc_h,kloc_p,kloc_s,minmaxeig);
+        find_min_max_eigenvalue_soloopenacc(conf_acc,fermions_parameters,kloc_r,kloc_h,kloc_p,kloc_s,minmaxeig);
         printf("Found eigenvalues of dirac operator: %e,  %e\n",
                 minmaxeig[0],minmaxeig[1]);
 
@@ -288,7 +288,7 @@ create(k_p_shiftferm_f[0:alloc_info.maxApproxOrder] )
     }
     for(r=0; r<test_settings.multiShiftInverterRepetitions; r++){
         gettimeofday(&t0,NULL);
-        multishift_invert(conf_acc[0],&fermions_parameters[0],
+        multishift_invert(conf_acc,&fermions_parameters[0],
                 rationalApproxToUse,
                 ferm_shiftmulti_acc,
                 ferm_chi_acc,
@@ -333,13 +333,13 @@ create(k_p_shiftferm_f[0:alloc_info.maxApproxOrder] )
         printf("####################\n");
     }
     // conversion to single precision
-    convert_double_to_float_su3_soa(conf_acc[0],conf_acc_f[0]);
+    convert_double_to_float_su3_soa(conf_acc,conf_acc_f);
     convert_double_to_float_vec3_soa(ferm_chi_acc,ferm_chi_acc_f);
 
     struct timeval t0_f,t1_f,t2_f,t3_f,t4_f,t5_f;
     for(r=0; r<test_settings.multiShiftInverterRepetitions; r++){
         gettimeofday(&t0_f,NULL);
-        multishift_invert_f(conf_acc_f[0],&fermions_parameters[0],
+        multishift_invert_f(conf_acc_f,&fermions_parameters[0],
                 rationalApproxToUse,
                 ferm_shiftmulti_acc_f,
                 ferm_chi_acc_f,


### PR DESCRIPTION
Tested MPI-parallel version of Hasenbusch Parallel Tempering.
The trick is to manage communications of salamino pieces inside replicas by using different communicators instead of MPI_COMM_WORLD, to ensure independence between HMC of different replicas. This required a hierarchical indexing for mpiranks, with a unique _world master_ (rank 0 of MPI_COMM_WORLD) managing the swap logic and one _replica master_ for each replica (rank 0 of `devinfo.mpi_comm`, which is different for each replica), managing the HMC of the replica as it was done before by the master in the implementation before replicas (`devinfo.myrank` is a local indexing within a replica, while `devinfo.myrank_world` is a global indexing).  
The labeling logic which identifies replicas with different defect conditions had to be rethought, and some overhead is introduced with respect to the serial version; however, this is negligible with respect to the HMC stage, which is now efficiently handled, so, for a fixed number of GPUs per replica, the gain in parallelization is almost linear in the number of replicas, since it is almost embarrassingly parallel.
There are still margins of optimization (in the swap logic, or in the openacc exclusive resync of the defect condition), 
but the implementation has been tested in some benchmarked cases, and it appears to be correct and with the expected performance gains.

The compilation script has been simplified (removed `DO_PARALLEL_TEMPERING`), 
but now we introduced a new parameter in geom_defines (`NREPLICAS`), 
which requires a specification of the number of replicas at compilation time.
Therefore, runs must be launched with a total number of NREPLICAS*NRANKS_D3 mpiranks.